### PR TITLE
Separate relay into exec and library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ ament_auto_add_library(relay_node SHARED
   src/relay_node.cpp
 )
 
+rclcpp_components_register_nodes(relay_node "topic_tools::RelayNode")
+
 ament_auto_add_executable(relay
   src/relay.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,23 +10,27 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 # find dependencies
-find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
-add_executable(relay src/relay.cpp)
-ament_target_dependencies(relay rclcpp)
+ament_auto_add_library(relay_node SHARED
+  src/relay_node.cpp
+)
 
-install(TARGETS
-  relay
-  DESTINATION lib/${PROJECT_NAME})
+ament_auto_add_executable(relay
+  src/relay.cpp
+)
 
-install(
-  DIRECTORY launch
-  DESTINATION share/${PROJECT_NAME})
+target_link_libraries(relay
+  relay_node
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_package()
+ament_auto_package(
+  INSTALL_TO_SHARE
+    launch
+)

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ ros2 run relay base_scan my_base_scan
 
 #### Parameters
 
-- `input_topic` (string) 
+- `input_topic` (string)
     - the same as if provided as a command line argument
-- `output_topic` (string, default=`<input_topic>_relay`) 
+- `output_topic` (string, default=`<input_topic>_relay`)
     - the same as if provided as a command line argument
 - `lazy` (bool, default=False)
-    - If True, only subscribe to `input_topic` if there is at least one subscriber on the `output_topic` 
+    - If True, only subscribe to `input_topic` if there is at least one subscriber on the `output_topic`

--- a/include/topic_tools/relay_node.hpp
+++ b/include/topic_tools/relay_node.hpp
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef TOPIC_TOOLS__RELAY_NODE_HPP_
+#define TOPIC_TOOLS__RELAY_NODE_HPP_
+
 #include <memory>
-#include <optional>
+#include <optional>  // NOLINT : https://github.com/ament/ament_lint/pull/324
 #include <string>
 #include <utility>
 
@@ -45,3 +48,5 @@ private:
   std::optional<rclcpp::QoS> qos_profile_;
 };
 }  // namespace topic_tools
+
+#endif  // TOPIC_TOOLS__RELAY_NODE_HPP_

--- a/include/topic_tools/relay_node.hpp
+++ b/include/topic_tools/relay_node.hpp
@@ -1,0 +1,47 @@
+// Copyright 2021 Mateusz Lichota
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "rclcpp/rclcpp.hpp"
+
+namespace topic_tools
+{
+class RelayNode : public rclcpp::Node
+{
+public:
+  explicit RelayNode(const rclcpp::NodeOptions & options);
+
+private:
+  void republish_message(std::shared_ptr<rclcpp::SerializedMessage> msg);
+  void make_subscribe_unsubscribe_decisions();
+
+  /// Returns an optional pair <topic type, QoS profile> of the first found source publishing
+  /// on `input_topic_` if at least one source is found
+  std::optional<std::pair<std::string, rclcpp::QoS>> try_discover_source();
+
+  std::chrono::duration<float> discovery_period_ = std::chrono::milliseconds{100};
+  rclcpp::GenericSubscription::SharedPtr sub_;
+  rclcpp::GenericPublisher::SharedPtr pub_;
+  rclcpp::TimerBase::SharedPtr discovery_timer_;
+  std::string input_topic_;
+  std::string output_topic_;
+  bool lazy_;
+  std::optional<std::string> topic_type_;
+  std::optional<rclcpp::QoS> qos_profile_;
+};
+}  // namespace topic_tools

--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="ros-tooling@googlegroups.com">ROS Tooling Working Group</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/src/relay.cpp
+++ b/src/relay.cpp
@@ -12,119 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
-#include <rclcpp/rclcpp.hpp>
-
-#include <rclcpp/generic_publisher.hpp>
-#include <rclcpp/generic_subscription.hpp>
-
 #include <memory>
-#include <string>
-#include <utility>
 
-namespace topic_tools
-{
-
-class RelayNode : public rclcpp::Node
-{
-public:
-  RelayNode(const std::string node_name, const rclcpp::NodeOptions & options);
-
-private:
-  void republish_message(std::shared_ptr<rclcpp::SerializedMessage> msg);
-  void make_subscribe_unsubscribe_decisions();
-
-  /// Returns an optional pair <topic type, QoS profile> of the first found source publishing
-  /// on `input_topic_` if at least one source is found
-  std::optional<std::pair<std::string, rclcpp::QoS>> try_discover_source();
-
-  std::chrono::duration<float> discovery_period_ = std::chrono::milliseconds{100};
-  rclcpp::GenericSubscription::SharedPtr sub_;
-  rclcpp::GenericPublisher::SharedPtr pub_;
-  rclcpp::TimerBase::SharedPtr discovery_timer_;
-  std::string input_topic_;
-  std::string output_topic_;
-  bool lazy_;
-  std::optional<std::string> topic_type_;
-  std::optional<rclcpp::QoS> qos_profile_;
-};
-
-RelayNode::RelayNode(
-  const std::string node_name, const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
-: rclcpp::Node(node_name, options)
-{
-  input_topic_ = declare_parameter<std::string>("input_topic");
-  output_topic_ = declare_parameter<std::string>("output_topic", input_topic_ + "_relay");
-  lazy_ = declare_parameter<bool>("lazy", false);
-
-  discovery_timer_ = this->create_wall_timer(
-    discovery_period_,
-    std::bind(&RelayNode::make_subscribe_unsubscribe_decisions, this));
-
-  make_subscribe_unsubscribe_decisions();
-}
-
-void RelayNode::make_subscribe_unsubscribe_decisions()
-{
-  if (auto source_info = try_discover_source()) {
-    // always relay same topic type and QoS profile as the first available source
-    if (*topic_type_ != source_info->first || *qos_profile_ != source_info->second) {
-      topic_type_ = source_info->first;
-      qos_profile_ = source_info->second;
-      pub_ = this->create_generic_publisher(output_topic_, *topic_type_, *qos_profile_);
-    }
-
-    // at this point it is certain that our publisher exists
-    if (!lazy_ || pub_->get_subscription_count() > 0) {
-      if (!sub_) {
-        sub_ = this->create_generic_subscription(
-          input_topic_, *topic_type_, *qos_profile_,
-          std::bind(&RelayNode::republish_message, this, std::placeholders::_1));
-      }
-    } else {
-      sub_.reset();
-    }
-  } else {
-    // we don't have any source to republish, so we don't need a publisher
-    // also, if the source topic type changes while it's offline this
-    // prevents a crash due to mismatched topic types
-    pub_.reset();
-  }
-}
-
-
-std::optional<std::pair<std::string, rclcpp::QoS>> RelayNode::try_discover_source()
-{
-  auto publishers_info = this->get_publishers_info_by_topic(input_topic_);
-  std::optional<rclcpp::QoS> qos_profile;
-  if (!publishers_info.empty()) {
-    return std::make_pair(publishers_info[0].topic_type(), publishers_info[0].qos_profile());
-  } else {
-    return {};
-  }
-}
-
-void RelayNode::republish_message(std::shared_ptr<rclcpp::SerializedMessage> msg)
-{
-  pub_->publish(*msg);
-}
-
-}  // namespace topic_tools
+#include "rclcpp/rclcpp.hpp"
+#include "topic_tools/relay_node.hpp"
 
 int main(int argc, char * argv[])
 {
-  rclcpp::init(argc, argv);
+  auto args = rclcpp::init_and_remove_ros_arguments(argc, argv);
+  auto options = rclcpp::NodeOptions{};
 
-  std::shared_ptr<topic_tools::RelayNode> node;
-  auto options = rclcpp::NodeOptions();
-
-  if (argc >= 2 && strcmp(argv[1], "--ros-args")) {
-    options.append_parameter_override("input_topic", argv[1]);
-    if (argc >= 3 && strcmp(argv[2], "--ros-args")) {
-      options.append_parameter_override("output_topic", argv[2]);
+  if (args.size() >= 2) {
+    options.append_parameter_override("input_topic", args.at(1));
+    if (args.size() >= 3) {
+      options.append_parameter_override("output_topic", args.at(2));
     }
   }
-  node = std::make_shared<topic_tools::RelayNode>("Relay", options);
+
+  auto node = std::make_shared<topic_tools::RelayNode>(options);
 
   rclcpp::spin(node);
   rclcpp::shutdown();

--- a/src/relay_node.cpp
+++ b/src/relay_node.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <memory>
-#include <optional>
+#include <optional> // NOLINT : https://github.com/ament/ament_lint/pull/324 
 #include <string>
 #include <utility>
 

--- a/src/relay_node.cpp
+++ b/src/relay_node.cpp
@@ -1,0 +1,87 @@
+// Copyright 2021 Mateusz Lichota
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "rclcpp/rclcpp.hpp"
+#include "topic_tools/relay_node.hpp"
+
+namespace topic_tools
+{
+RelayNode::RelayNode(const rclcpp::NodeOptions & options)
+: rclcpp::Node("relay", options)
+{
+  input_topic_ = declare_parameter<std::string>("input_topic");
+  output_topic_ = declare_parameter<std::string>("output_topic", input_topic_ + "_relay");
+  lazy_ = declare_parameter<bool>("lazy", false);
+
+  discovery_timer_ = this->create_wall_timer(
+    discovery_period_,
+    std::bind(&RelayNode::make_subscribe_unsubscribe_decisions, this));
+
+  make_subscribe_unsubscribe_decisions();
+}
+
+void RelayNode::make_subscribe_unsubscribe_decisions()
+{
+  if (auto source_info = try_discover_source()) {
+    // always relay same topic type and QoS profile as the first available source
+    if (*topic_type_ != source_info->first || *qos_profile_ != source_info->second) {
+      topic_type_ = source_info->first;
+      qos_profile_ = source_info->second;
+      pub_ = this->create_generic_publisher(output_topic_, *topic_type_, *qos_profile_);
+    }
+
+    // at this point it is certain that our publisher exists
+    if (!lazy_ || pub_->get_subscription_count() > 0) {
+      if (!sub_) {
+        sub_ = this->create_generic_subscription(
+          input_topic_, *topic_type_, *qos_profile_,
+          std::bind(&RelayNode::republish_message, this, std::placeholders::_1));
+      }
+    } else {
+      sub_.reset();
+    }
+  } else {
+    // we don't have any source to republish, so we don't need a publisher
+    // also, if the source topic type changes while it's offline this
+    // prevents a crash due to mismatched topic types
+    pub_.reset();
+  }
+}
+
+
+std::optional<std::pair<std::string, rclcpp::QoS>> RelayNode::try_discover_source()
+{
+  auto publishers_info = this->get_publishers_info_by_topic(input_topic_);
+  std::optional<rclcpp::QoS> qos_profile;
+  if (!publishers_info.empty()) {
+    return std::make_pair(publishers_info[0].topic_type(), publishers_info[0].qos_profile());
+  } else {
+    return {};
+  }
+}
+
+void RelayNode::republish_message(std::shared_ptr<rclcpp::SerializedMessage> msg)
+{
+  pub_->publish(*msg);
+}
+
+}  // namespace topic_tools
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(topic_tools::RelayNode)

--- a/src/relay_node.cpp
+++ b/src/relay_node.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <memory>
-#include <optional> // NOLINT : https://github.com/ament/ament_lint/pull/324 
+#include <optional> // NOLINT : https://github.com/ament/ament_lint/pull/324
 #include <string>
 #include <utility>
 


### PR DESCRIPTION
Separate `relay` into exec and library to load `relay` as compoent.