### PR TITLE
add visibility_control header. fixes windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ ament_auto_add_library(relay_node SHARED
   src/relay_node.cpp
   src/tool_base_node.cpp
 )
+target_compile_definitions(relay_node PRIVATE "TOPIC_TOOLS_BUILDING_LIBRARY")
 
 rclcpp_components_register_nodes(relay_node "topic_tools::RelayNode")
 
@@ -68,6 +69,7 @@ ament_auto_add_library(throttle_node SHARED
   src/throttle_node.cpp
   src/tool_base_node.cpp
 )
+target_compile_definitions(throttle_node PRIVATE "TOPIC_TOOLS_BUILDING_LIBRARY")
 
 rclcpp_components_register_nodes(throttle_node "topic_tools::ThrottleNode")
 
@@ -83,6 +85,7 @@ ament_auto_add_library(drop_node SHARED
   src/drop_node.cpp
   src/tool_base_node.cpp
 )
+target_compile_definitions(drop_node PRIVATE "TOPIC_TOOLS_BUILDING_LIBRARY")
 
 rclcpp_components_register_nodes(drop_node "topic_tools::DropNode")
 

--- a/include/topic_tools/drop_node.hpp
+++ b/include/topic_tools/drop_node.hpp
@@ -22,12 +22,14 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "topic_tools/tool_base_node.hpp"
+#include "visibility_control.h"
 
 namespace topic_tools
 {
 class DropNode final : public ToolBaseNode
 {
 public:
+  TOPIC_TOOLS_PUBLIC
   explicit DropNode(const rclcpp::NodeOptions & options);
 
 private:

--- a/include/topic_tools/drop_node.hpp
+++ b/include/topic_tools/drop_node.hpp
@@ -22,7 +22,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "topic_tools/tool_base_node.hpp"
-#include "visibility_control.h"
+#include "topic_tools/visibility_control.h"
 
 namespace topic_tools
 {

--- a/include/topic_tools/relay_node.hpp
+++ b/include/topic_tools/relay_node.hpp
@@ -22,12 +22,14 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "topic_tools/tool_base_node.hpp"
+#include "visibility_control.h"
 
 namespace topic_tools
 {
 class RelayNode final : public ToolBaseNode
 {
 public:
+  TOPIC_TOOLS_PUBLIC
   explicit RelayNode(const rclcpp::NodeOptions & options);
 
 private:

--- a/include/topic_tools/relay_node.hpp
+++ b/include/topic_tools/relay_node.hpp
@@ -22,7 +22,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "topic_tools/tool_base_node.hpp"
-#include "visibility_control.h"
+#include "topic_tools/visibility_control.h"
 
 namespace topic_tools
 {

--- a/include/topic_tools/throttle_node.hpp
+++ b/include/topic_tools/throttle_node.hpp
@@ -23,6 +23,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "topic_tools/tool_base_node.hpp"
+#include "visibility_control.h"
 
 namespace topic_tools
 {
@@ -31,6 +32,7 @@ class ThrottleNode final : public ToolBaseNode
   using Sent = std::pair<double, uint32_t>;
 
 public:
+  TOPIC_TOOLS_PUBLIC
   explicit ThrottleNode(const rclcpp::NodeOptions & options);
 
 private:

--- a/include/topic_tools/throttle_node.hpp
+++ b/include/topic_tools/throttle_node.hpp
@@ -23,7 +23,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "topic_tools/tool_base_node.hpp"
-#include "visibility_control.h"
+#include "topic_tools/visibility_control.h"
 
 namespace topic_tools
 {

--- a/include/topic_tools/tool_base_node.hpp
+++ b/include/topic_tools/tool_base_node.hpp
@@ -21,12 +21,14 @@
 #include <utility>
 
 #include "rclcpp/rclcpp.hpp"
+#include "visibility_control.h"
 
 namespace topic_tools
 {
 class ToolBaseNode : public rclcpp::Node
 {
 public:
+  TOPIC_TOOLS_PUBLIC
   ToolBaseNode(const std::string & node_name, const rclcpp::NodeOptions & options);
 
 private:

--- a/include/topic_tools/tool_base_node.hpp
+++ b/include/topic_tools/tool_base_node.hpp
@@ -21,7 +21,7 @@
 #include <utility>
 
 #include "rclcpp/rclcpp.hpp"
-#include "visibility_control.h"
+#include "topic_tools/visibility_control.h"
 
 namespace topic_tools
 {

--- a/include/topic_tools/visibility_control.h
+++ b/include/topic_tools/visibility_control.h
@@ -1,3 +1,17 @@
+// Copyright 2022 Melvin Wang
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef TOPIC_TOOLS__VISIBILITY_CONTROL_H_
 #define TOPIC_TOOLS__VISIBILITY_CONTROL_H_
 

--- a/include/topic_tools/visibility_control.h
+++ b/include/topic_tools/visibility_control.h
@@ -1,0 +1,35 @@
+#ifndef TOPIC_TOOLS__VISIBILITY_CONTROL_H_
+#define TOPIC_TOOLS__VISIBILITY_CONTROL_H_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define TOPIC_TOOLS_EXPORT __attribute__ ((dllexport))
+    #define TOPIC_TOOLS_IMPORT __attribute__ ((dllimport))
+  #else
+    #define TOPIC_TOOLS_EXPORT __declspec(dllexport)
+    #define TOPIC_TOOLS_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef TOPIC_TOOLS_BUILDING_LIBRARY
+    #define TOPIC_TOOLS_PUBLIC TOPIC_TOOLS_EXPORT
+  #else
+    #define TOPIC_TOOLS_PUBLIC TOPIC_TOOLS_IMPORT
+  #endif
+  #define TOPIC_TOOLS_PUBLIC_TYPE TOPIC_TOOLS_PUBLIC
+  #define TOPIC_TOOLS_LOCAL
+#else
+  #define TOPIC_TOOLS_EXPORT __attribute__ ((visibility("default")))
+  #define TOPIC_TOOLS_IMPORT
+  #if __GNUC__ >= 4
+    #define TOPIC_TOOLS_PUBLIC __attribute__ ((visibility("default")))
+    #define TOPIC_TOOLS_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define TOPIC_TOOLS_PUBLIC
+    #define TOPIC_TOOLS_LOCAL
+  #endif
+  #define TOPIC_TOOLS_PUBLIC_TYPE
+#endif
+
+#endif  // TOPIC_TOOLS__VISIBILITY_CONTROL_H_


### PR DESCRIPTION
Firstly, super happy this is getting ported to ros2!

This pr fixes the build on windows by adding a visibility header. I tested some of the executables (ex. drop) and they are functioning as expected. 