### PR TITLE
Expand now and auto values

### DIFF
--- a/topic_tools/package.xml
+++ b/topic_tools/package.xml
@@ -21,7 +21,8 @@
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>ros2cli</exec_depend>
-  <exec_depend>rosidl_runtime_py</exec_depend>
+  <exec_depend condition="$ROS_DISTRO == humble" version_gt="0.9.2">rosidl_runtime_py</exec_depend>
+  <exec_depend condition="$ROS_DISTRO == rolling" version_gte="0.11.0">rosidl_runtime_py</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/topic_tools/topic_tools/relay_field.py
+++ b/topic_tools/topic_tools/relay_field.py
@@ -149,7 +149,11 @@ class RelayField(Node):
             raise RuntimeError(f'Invalid field: {ex}')
 
         msg = self.output_class()
-        set_message_fields(msg, pub_args)
+        timestamp_fields = set_message_fields(
+            msg, pub_args, expand_header_auto=True, expand_time_now=True)
+        stamp_now = self.get_clock().now().to_msg()
+        for field_setter in timestamp_fields:
+            field_setter(stamp_now)
         self.pub.publish(msg)
 
 


### PR DESCRIPTION
This expands the `now` and `auto` values for `builtin_interfaces/msg/Time` and `std_msgs/msg/Header` fields respectively. This depends on a new release of `rosidl_runtime_py` for Humble (which hasn't been tagged yet).

Depends on #42

See https://github.com/ros2/ros2cli/issues/700 https://github.com/ros2/rosidl_runtime_py/pull/19 and https://github.com/ros2/rosidl_runtime_py/pull/20 for context