### PR TITLE
Fixing conditional jump based on uninitialized optional values

### DIFF
--- a/topic_tools/src/tool_base_node.cpp
+++ b/topic_tools/src/tool_base_node.cpp
@@ -31,7 +31,7 @@ void ToolBaseNode::make_subscribe_unsubscribe_decisions()
 {
   if (auto source_info = try_discover_source()) {
     // always relay same topic type and QoS profile as the first available source
-    if (*topic_type_ != source_info->first || *qos_profile_ != source_info->second || !pub_) {
+    if (!topic_type_ || !qos_profile_ || *topic_type_ != source_info->first || *qos_profile_ != source_info->second || !pub_) {
       topic_type_ = source_info->first;
       qos_profile_ = source_info->second;
       pub_ = this->create_generic_publisher(output_topic_, *topic_type_, *qos_profile_);

--- a/topic_tools/src/tool_base_node.cpp
+++ b/topic_tools/src/tool_base_node.cpp
@@ -31,7 +31,9 @@ void ToolBaseNode::make_subscribe_unsubscribe_decisions()
 {
   if (auto source_info = try_discover_source()) {
     // always relay same topic type and QoS profile as the first available source
-    if (!topic_type_ || !qos_profile_ || *topic_type_ != source_info->first || *qos_profile_ != source_info->second || !pub_) {
+    if (!topic_type_ || !qos_profile_ || *topic_type_ != source_info->first ||
+      *qos_profile_ != source_info->second || !pub_)
+    {
       topic_type_ = source_info->first;
       qos_profile_ = source_info->second;
       pub_ = this->create_generic_publisher(output_topic_, *topic_type_, *qos_profile_);


### PR DESCRIPTION
This pull request aims to fix a potentially dangerous usage of `std::optional` in which a conditional jump is made based on uninitialized value (or values). The fix eliminates the following error message issued by Valgrind: "Conditional jump or move depends on uninitialised value(s)". Quoting [cppreference.com](https://en.cppreference.com/w/cpp/utility/optional/operator*): `std::optional<T>::operator*` _does not check whether the optional contains a value!_