### PR TITLE
Eliminate race condition in relay node

### DIFF
--- a/topic_tools/include/topic_tools/tool_base_node.hpp
+++ b/topic_tools/include/topic_tools/tool_base_node.hpp
@@ -19,6 +19,7 @@
 #include <optional>  // NOLINT : https://github.com/ament/ament_lint/pull/324
 #include <string>
 #include <utility>
+#include <mutex>
 
 #include "rclcpp/rclcpp.hpp"
 #include "topic_tools/visibility_control.h"
@@ -48,6 +49,7 @@ protected:
   rclcpp::TimerBase::SharedPtr discovery_timer_;
   rclcpp::GenericPublisher::SharedPtr pub_;
   rclcpp::GenericSubscription::SharedPtr sub_;
+  std::mutex pub_mutex_;
 };
 }  // namespace topic_tools
 

--- a/topic_tools/src/relay_node.cpp
+++ b/topic_tools/src/relay_node.cpp
@@ -38,7 +38,9 @@ RelayNode::RelayNode(const rclcpp::NodeOptions & options)
 
 void RelayNode::process_message(std::shared_ptr<rclcpp::SerializedMessage> msg)
 {
-  pub_->publish(*msg);
+  std::scoped_lock lock(pub_mutex_);
+  if(pub_)
+    pub_->publish(*msg);
 }
 
 }  // namespace topic_tools

--- a/topic_tools/src/relay_node.cpp
+++ b/topic_tools/src/relay_node.cpp
@@ -39,8 +39,9 @@ RelayNode::RelayNode(const rclcpp::NodeOptions & options)
 void RelayNode::process_message(std::shared_ptr<rclcpp::SerializedMessage> msg)
 {
   std::scoped_lock lock(pub_mutex_);
-  if(pub_)
+  if (pub_) {
     pub_->publish(*msg);
+  }
 }
 
 }  // namespace topic_tools

--- a/topic_tools/src/tool_base_node.cpp
+++ b/topic_tools/src/tool_base_node.cpp
@@ -36,6 +36,7 @@ void ToolBaseNode::make_subscribe_unsubscribe_decisions()
     {
       topic_type_ = source_info->first;
       qos_profile_ = source_info->second;
+      std::scoped_lock lock(pub_mutex_);
       pub_ = this->create_generic_publisher(output_topic_, *topic_type_, *qos_profile_);
     }
 
@@ -55,6 +56,7 @@ void ToolBaseNode::make_subscribe_unsubscribe_decisions()
     // we don't have any source to republish, so we don't need a publisher
     // also, if the source topic type changes while it's offline this
     // prevents a crash due to mismatched topic types
+    std::scoped_lock lock(pub_mutex_);
     pub_.reset();
   }
 }


### PR DESCRIPTION
Added use of mutex to eliminate race condition causing segmentation fault in `process_message` method.
Scenario for the race condition:
1. Relay working on default parameters, outer publisher publishing on `<intopic>`, outer subscriber subscribed on `<outtopic>`
2. Outer publisher stops publishing (killed or whatever)
3. Outer publisher starts publishing again

Reason:
The subscriber on `<intopic>` wasn't destroyed when outer publisher was killed, but publisher on `<outtopic>` was. Therefore when outer publisher starts publishing again, it's possible that callback from the subscriber will be called before the `<outtopic>` publisher is created, and it tries to call publish method on non-exisiting object.

Solution:
Mutex lock access to `<outtopic>` publisher.