### PR TITLE
Add a basic unit test for relay_node

### DIFF
--- a/topic_tools/CMakeLists.txt
+++ b/topic_tools/CMakeLists.txt
@@ -85,6 +85,8 @@ target_link_libraries(mux
 )
 
 if(BUILD_TESTING)
+  find_package(std_msgs REQUIRED)
+
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 

--- a/topic_tools/CMakeLists.txt
+++ b/topic_tools/CMakeLists.txt
@@ -87,6 +87,20 @@ target_link_libraries(mux
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_relay test/test_relay.cpp)
+  target_include_directories(test_relay PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+  ament_target_dependencies(test_relay
+    rclcpp
+    std_msgs
+  )
+  target_link_libraries(test_relay
+    relay_node
+  )
 endif()
 
 ament_auto_package(

--- a/topic_tools/package.xml
+++ b/topic_tools/package.xml
@@ -27,6 +27,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>std_msgs</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/topic_tools/package.xml
+++ b/topic_tools/package.xml
@@ -26,6 +26,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/topic_tools/test/test_relay.cpp
+++ b/topic_tools/test/test_relay.cpp
@@ -58,7 +58,6 @@ TEST_F(TestRelay, MessagesAreEffectivelyRelayed) {
     message.data = msg_content;
     publisher->publish(message);
 
-    rclcpp::spin_some(test_node);
     rclcpp::spin_some(target_node);
     rclcpp::spin_some(test_node);
   }

--- a/topic_tools/test/test_relay.cpp
+++ b/topic_tools/test/test_relay.cpp
@@ -1,0 +1,69 @@
+// Copyright 2023 Martin Llofriu
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
+
+#include "topic_tools/relay_node.hpp"
+
+class TestRelay : public ::testing::Test
+{
+public:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
+  void topic_callback(const std_msgs::msg::String::SharedPtr msg)
+  {
+    ASSERT_EQ(msg->data, expected_msg);
+    received_relays++;
+  }
+
+  std::string expected_msg;
+  int received_relays{0};
+};
+
+TEST_F(TestRelay, MessagesAreEffectivelyRelayed) {
+  using std::placeholders::_1;
+  auto test_node = rclcpp::Node::make_shared("MessagesAreEffectivelyRelayed");
+  auto subscription = test_node->create_subscription<std_msgs::msg::String>(
+    "/relay_test/output", 10, std::bind(&TestRelay::topic_callback, this, _1));
+  auto publisher = test_node->create_publisher<std_msgs::msg::String>("/relay_test/input", 10);
+  rclcpp::spin_some(test_node);
+
+  auto options = rclcpp::NodeOptions{};
+  options.append_parameter_override("input_topic", "/relay_test/input");
+  options.append_parameter_override("output_topic", "/relay_test/output");
+  auto target_node = std::make_shared<topic_tools::RelayNode>(options);
+  rclcpp::spin_some(target_node);
+
+  for (std::string msg_content : {"hello", "again"}) {
+    expected_msg = msg_content;
+
+    auto message = std_msgs::msg::String();
+    message.data = msg_content;
+    publisher->publish(message);
+
+    rclcpp::spin_some(test_node);
+    rclcpp::spin_some(target_node);
+    rclcpp::spin_some(test_node);
+  }
+
+  ASSERT_EQ(received_relays, 2);
+}

--- a/topic_tools/test/test_relay.cpp
+++ b/topic_tools/test/test_relay.cpp
@@ -45,13 +45,11 @@ TEST_F(TestRelay, MessagesAreEffectivelyRelayed) {
   auto subscription = test_node->create_subscription<std_msgs::msg::String>(
     "/relay_test/output", 10, std::bind(&TestRelay::topic_callback, this, _1));
   auto publisher = test_node->create_publisher<std_msgs::msg::String>("/relay_test/input", 10);
-  rclcpp::spin_some(test_node);
 
   auto options = rclcpp::NodeOptions{};
   options.append_parameter_override("input_topic", "/relay_test/input");
   options.append_parameter_override("output_topic", "/relay_test/output");
   auto target_node = std::make_shared<topic_tools::RelayNode>(options);
-  rclcpp::spin_some(target_node);
 
   for (std::string msg_content : {"hello", "again"}) {
     expected_msg = msg_content;


### PR DESCRIPTION
I'm trying to implement the feature request I created here - https://github.com/ros-tooling/topic_tools/issues/58.

In doing so, I found myself refactoring code in tool_base_node.

In order to prevent breaking things, I figured I'd write some unit tests for the existing functionality. 

I'm creating this pull request as a draft to get some early feedback. If we agree on it, I can apply the same pattern to the other tools in topic_tools.