### PR TITLE
Performance improvement in Python scripts

### DIFF
--- a/topic_tools/topic_tools/relay_field.py
+++ b/topic_tools/topic_tools/relay_field.py
@@ -150,7 +150,11 @@ class RelayField(Node):
             raise RuntimeError(f'Invalid field: {ex}')
 
         msg = self.output_class()
-        set_message_fields(msg, pub_args)
+        timestamp_fields = set_message_fields(
+            msg, pub_args, expand_header_auto=True, expand_time_now=True)
+        stamp_now = self.get_clock().now().to_msg()
+        for field_setter in timestamp_fields:
+            field_setter(stamp_now)
         self.pub.publish(msg)
 
 

--- a/topic_tools/topic_tools/relay_field.py
+++ b/topic_tools/topic_tools/relay_field.py
@@ -28,7 +28,6 @@ import argparse
 import copy
 import os
 import sys
-import functools
 
 import rclpy
 from rclpy.node import Node
@@ -69,7 +68,6 @@ class RelayField(Node):
         self.sub = self.create_subscription(
             input_class, input_topic_in_ns, self.callback, qos_profile)
 
-    @functools.lru_cache(maxsize=256)
     def _eval_in_dict_impl(self, dict_, globals_, locals_):
         res = copy.deepcopy(dict_)
         for k, v in res.items():
@@ -151,11 +149,7 @@ class RelayField(Node):
             raise RuntimeError(f'Invalid field: {ex}')
 
         msg = self.output_class()
-        timestamp_fields = set_message_fields(
-            msg, pub_args, expand_header_auto=True, expand_time_now=True)
-        stamp_now = self.get_clock().now().to_msg()
-        for field_setter in timestamp_fields:
-            field_setter(stamp_now)
+        set_message_fields(msg, pub_args)
         self.pub.publish(msg)
 
 

--- a/topic_tools/topic_tools/relay_field.py
+++ b/topic_tools/topic_tools/relay_field.py
@@ -48,7 +48,8 @@ class RelayField(Node):
         super().__init__(f'relay_field_{os.getpid()}')
 
         self.msg_generation = yaml.safe_load(args.expression)
-        self.msg_generation_lambda = lambda m: self._eval_in_dict_impl(self.msg_generation, None, {'m': m})
+        self.msg_generation_lambda = lambda m: self._eval_in_dict_impl(
+            self.msg_generation, None, {'m': m})
 
         input_topic_in_ns = args.input
         if not input_topic_in_ns.startswith('/'):

--- a/topic_tools/topic_tools/setup.cfg
+++ b/topic_tools/topic_tools/setup.cfg
@@ -1,7 +1,7 @@
 [develop]
-script-dir=$base/lib/topic_tools
+script_dir=$base/lib/topic_tools
 [install]
-install-scripts=$base/lib/topic_tools
+install_scripts=$base/lib/topic_tools
 [options.entry_points]
 console_scripts =
     relay_field = topic_tools.relay_field:main


### PR DESCRIPTION
Improved `relay_field` and `transform` nodes.
- Used `lambda` to pre-bake string eval and yaml-based field search. This yields approx. 50% in performance improvements (from 30% of a core to 12% of a core for `transform` that calculates the norm of a vector and publish a scalar).
