### PR TITLE
Build incrementally on Rolling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,13 @@ jobs:
     container:
       image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     steps:
+    - uses: ros-tooling/setup-ros@v0.6
+      with:
+        required-ros-distributions: iron
     - uses: ros-tooling/action-ros-ci@v0.3
       with:
         package-name: topic_tools topic_tools_interfaces
         target-ros2-distro: rolling
-        vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
         colcon-defaults: |
           {
             "build": {


### PR DESCRIPTION
users building against unreleased features can use action-ros-ci repos file