### PR TITLE
[FIX] convert rclcpp to  chrono

### DIFF
--- a/topic_tools/src/throttle_node.cpp
+++ b/topic_tools/src/throttle_node.cpp
@@ -34,7 +34,7 @@ ThrottleNode::ThrottleNode(const rclcpp::NodeOptions & options)
   if (throttle_type_str == "messages") {
     throttle_type_ = ThrottleType::MESSAGES;
     msgs_per_sec_ = declare_parameter<double>("msgs_per_sec");
-    period_ = rclcpp::Rate(msgs_per_sec_).period();
+    period_ = rclcpp::Rate(msgs_per_sec_).period().to_chrono<decltype(period_)>();
   } else if (throttle_type_str == "bytes") {
     throttle_type_ = ThrottleType::BYTES;
     bytes_per_sec_ = declare_parameter<int>("bytes_per_sec");


### PR DESCRIPTION
With a recent update of `rclcpp::Rate` the return value of `.period()` changed to `rclcpp::Duration`, thus, it must be converted to the `std::chrono::duration` used here.

https://github.com/ros2/rclcpp/commit/bc435776a257fcf76c5b0124bec26f6824342e34 here are the respective changes in `rclcpp`

action-ros-ci-repos-supplemental: https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos