### PR TITLE
Add demux

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The tools in this package are provided as composable ROS 2 component nodes, so t
 - [Throttle](#throttle): Republishes data with bandwidth or rate limit.
 - [Drop](#drop): Republishes by dropping X out of every Y incoming messages.
 - [Mux](#mux): Multiplexes incoming topics to an output.
+- [Demux](#demux): Demultiplexes an incoming topic to one of multiple outputs
 - [Delay](#delay): Delays and republishes incoming data.
 
 ### Relay
@@ -207,6 +208,37 @@ ros2 run topic_tools mux sel_cmdvel auto_cmdvel joystick_cmdvel
     - If True, only subscribe to `input_topic` if there is at least one subscriber on the `output_topic`
 - `initial_topic` (str, default="")
     - Input topic to select on startup. If `__none`, start with no input topic. If unset, default to first topic in arguments
+
+### Demux
+
+demux is a ROS2 node that subscribes to an incoming topic and republishes incoming data to one of many topic,
+i.e., it's a demultiplexer that switches an input towards 1 of N outputs. Services are offered to switch among output topics,
+and to add and delete output topics. At startup, the first output topic on the command line is selected.
+
+#### Usage
+
+```shell
+ros2 run topic_tools demux <intopic> <outopic1> [outopic2...]
+```
+
+Subscribe to <intopic1> and publish currently to selected outopic among <outopic1>...N. demux will start with <outopic1> selected.
+- `inttopic`: Incoming topic to subscribe to
+- `outopicN`: Outgoing topic to publish on
+
+E.g. demux one command stream (cmdvel) between two command streams (turtle1_cmdvel and turtle2_cmdvel):
+
+```shell
+ros2 run topic_tools demux cmdvel turtle1_cmdvel turtle2_cmdvel
+```
+
+#### Parameters
+
+- `input_topic` (string, default=`~/input`)
+    - the same as if provided as a command line argument
+- `output_topics` (string array)
+    - the same as if provided as a command line argument
+- `initial_topic` (str, default="")
+    - Output topic to select on startup. If `__none`, start with no output topic. If unset, default to first topic in arguments
 
 ### Delay
 

--- a/README.md
+++ b/README.md
@@ -185,10 +185,10 @@ and to add and delete input topics. At startup, the first input topic on the com
 #### Usage
 
 ```shell
-ros2 run topic_tools mux <outopic> <intopic1> [intopic2...]
+ros2 run topic_tools mux <outtopic> <intopic1> [intopic2...]
 ```
 
-Subscribe to <intopic1>...N and publish currently selected topic to outopic. mux will start with <intopic1> selected.
+Subscribe to <intopic1>...N and publish currently selected topic to outtopic. mux will start with <intopic1> selected.
 - `outtopic`: Outgoing topic to publish on
 - `intopicN`: Incoming topic to subscribe to
 
@@ -218,12 +218,12 @@ and to add and delete output topics. At startup, the first output topic on the c
 #### Usage
 
 ```shell
-ros2 run topic_tools demux <intopic> <outtopic1> [outopic2...]
+ros2 run topic_tools demux <intopic> <outtopic1> [outtopic2...]
 ```
 
-Subscribe to <intopic1> and publish currently to selected outopic among <outopic1>...N. demux will start with <outopic1> selected.
+Subscribe to <intopic1> and publish currently to selected outtopic among <outtopic1>...N. demux will start with <outtopic1> selected.
 - `intopic`: Incoming topic to subscribe to
-- `outopicN`: Outgoing topic to publish on
+- `outtopicN`: Outgoing topic to publish on
 
 E.g. demux one command stream (cmdvel) between two command streams (turtle1_cmdvel and turtle2_cmdvel):
 

--- a/README.md
+++ b/README.md
@@ -218,11 +218,11 @@ and to add and delete output topics. At startup, the first output topic on the c
 #### Usage
 
 ```shell
-ros2 run topic_tools demux <intopic> <outopic1> [outopic2...]
+ros2 run topic_tools demux <intopic> <outtopic1> [outopic2...]
 ```
 
 Subscribe to <intopic1> and publish currently to selected outopic among <outopic1>...N. demux will start with <outopic1> selected.
-- `inttopic`: Incoming topic to subscribe to
+- `intopic`: Incoming topic to subscribe to
 - `outopicN`: Outgoing topic to publish on
 
 E.g. demux one command stream (cmdvel) between two command streams (turtle1_cmdvel and turtle2_cmdvel):

--- a/topic_tools/CMakeLists.txt
+++ b/topic_tools/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(topic_tools)
 
+find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(topic_tools_interfaces REQUIRED)

--- a/topic_tools/CMakeLists.txt
+++ b/topic_tools/CMakeLists.txt
@@ -84,6 +84,22 @@ target_link_libraries(mux
   mux_node
 )
 
+ament_auto_add_library(demux_node SHARED
+  src/demux_node.cpp
+  src/tool_base_node.cpp
+)
+target_compile_definitions(demux_node PRIVATE "TOPIC_TOOLS_BUILDING_LIBRARY")
+
+rclcpp_components_register_nodes(demux_node "topic_tools::DemuxNode")
+
+ament_auto_add_executable(demux
+  src/demux.cpp
+)
+
+target_link_libraries(demux
+  demux_node
+)
+
 ament_auto_add_library(delay_node SHARED
   src/delay_node.cpp
   src/tool_base_node.cpp
@@ -148,6 +164,18 @@ if(BUILD_TESTING)
 
   target_link_libraries(test_mux
     mux_node
+    rclcpp::rclcpp
+    ${std_msgs_TARGETS}
+  )
+
+  ament_add_gtest(test_demux test/test_demux.cpp)
+  target_include_directories(test_demux PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+
+  target_link_libraries(test_demux
+    demux_node
     rclcpp::rclcpp
     ${std_msgs_TARGETS}
   )

--- a/topic_tools/CMakeLists.txt
+++ b/topic_tools/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.8)
 project(topic_tools)
 
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(topic_tools_interfaces REQUIRED)
+
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
@@ -9,26 +13,18 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# find dependencies
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
+include_directories(include)
 
-ament_python_install_package(${PROJECT_NAME}
-  SETUP_CFG
-    ${PROJECT_NAME}/setup.cfg
-  SCRIPTS_DESTINATION
-    lib/${PROJECT_NAME}
-)
-
-ament_auto_add_library(relay_node SHARED
+add_library(relay_node SHARED
   src/relay_node.cpp
   src/tool_base_node.cpp
 )
+ament_target_dependencies(relay_node rclcpp rclcpp_components)
 target_compile_definitions(relay_node PRIVATE "TOPIC_TOOLS_BUILDING_LIBRARY")
 
 rclcpp_components_register_nodes(relay_node "topic_tools::RelayNode")
 
-ament_auto_add_executable(relay
+add_executable(relay
   src/relay.cpp
 )
 
@@ -36,15 +32,16 @@ target_link_libraries(relay
   relay_node
 )
 
-ament_auto_add_library(throttle_node SHARED
+add_library(throttle_node SHARED
   src/throttle_node.cpp
   src/tool_base_node.cpp
 )
+ament_target_dependencies(throttle_node rclcpp rclcpp_components)
 target_compile_definitions(throttle_node PRIVATE "TOPIC_TOOLS_BUILDING_LIBRARY")
 
 rclcpp_components_register_nodes(throttle_node "topic_tools::ThrottleNode")
 
-ament_auto_add_executable(throttle
+add_executable(throttle
   src/throttle.cpp
 )
 
@@ -52,15 +49,16 @@ target_link_libraries(throttle
   throttle_node
 )
 
-ament_auto_add_library(drop_node SHARED
+add_library(drop_node SHARED
   src/drop_node.cpp
   src/tool_base_node.cpp
 )
+ament_target_dependencies(drop_node rclcpp rclcpp_components)
 target_compile_definitions(drop_node PRIVATE "TOPIC_TOOLS_BUILDING_LIBRARY")
 
 rclcpp_components_register_nodes(drop_node "topic_tools::DropNode")
 
-ament_auto_add_executable(drop
+add_executable(drop
   src/drop.cpp
 )
 
@@ -68,15 +66,16 @@ target_link_libraries(drop
   drop_node
 )
 
-ament_auto_add_library(mux_node SHARED
+add_library(mux_node SHARED
   src/mux_node.cpp
   src/tool_base_node.cpp
 )
+ament_target_dependencies(mux_node rclcpp rclcpp_components topic_tools_interfaces)
 target_compile_definitions(mux_node PRIVATE "TOPIC_TOOLS_BUILDING_LIBRARY")
 
 rclcpp_components_register_nodes(mux_node "topic_tools::MuxNode")
 
-ament_auto_add_executable(mux
+add_executable(mux
   src/mux.cpp
 )
 
@@ -84,15 +83,16 @@ target_link_libraries(mux
   mux_node
 )
 
-ament_auto_add_library(demux_node SHARED
+add_library(demux_node SHARED
   src/demux_node.cpp
   src/tool_base_node.cpp
 )
+ament_target_dependencies(demux_node rclcpp rclcpp_components topic_tools_interfaces)
 target_compile_definitions(demux_node PRIVATE "TOPIC_TOOLS_BUILDING_LIBRARY")
 
 rclcpp_components_register_nodes(demux_node "topic_tools::DemuxNode")
 
-ament_auto_add_executable(demux
+add_executable(demux
   src/demux.cpp
 )
 
@@ -100,15 +100,16 @@ target_link_libraries(demux
   demux_node
 )
 
-ament_auto_add_library(delay_node SHARED
+add_library(delay_node SHARED
   src/delay_node.cpp
   src/tool_base_node.cpp
 )
+ament_target_dependencies(delay_node rclcpp rclcpp_components)
 target_compile_definitions(delay_node PRIVATE "TOPIC_TOOLS_BUILDING_LIBRARY")
 
 rclcpp_components_register_nodes(delay_node "topic_tools::DelayNode")
 
-ament_auto_add_executable(delay
+add_executable(delay
   src/delay.cpp
 )
 
@@ -181,7 +182,12 @@ if(BUILD_TESTING)
   )
 endif()
 
-ament_auto_package(
-  INSTALL_TO_SHARE
-    launch
+install(TARGETS relay_node relay throttle_node throttle drop_node drop mux_node mux demux_node demux delay_node delay
+  DESTINATION lib/${PROJECT_NAME}
 )
+
+install(DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/topic_tools/include/topic_tools/demux_node.hpp
+++ b/topic_tools/include/topic_tools/demux_node.hpp
@@ -54,7 +54,7 @@ private:
     const std::shared_ptr<topic_tools_interfaces::srv::DemuxSelect::Request> request,
     std::shared_ptr<topic_tools_interfaces::srv::DemuxSelect::Response> response);
 
-  std::vector<std::string> input_topics_;
+  std::vector<std::string> output_topics_;
   rclcpp::Service<topic_tools_interfaces::srv::DemuxAdd>::SharedPtr demux_add_srv_;
   rclcpp::Service<topic_tools_interfaces::srv::DemuxDelete>::SharedPtr demux_delete_srv_;
   rclcpp::Service<topic_tools_interfaces::srv::DemuxList>::SharedPtr demux_list_srv_;

--- a/topic_tools/include/topic_tools/demux_node.hpp
+++ b/topic_tools/include/topic_tools/demux_node.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TOPIC_TOOLS__MUX_NODE_HPP_
-#define TOPIC_TOOLS__MUX_NODE_HPP_
+#ifndef TOPIC_TOOLS__DEMUX_NODE_HPP_
+#define TOPIC_TOOLS__DEMUX_NODE_HPP_
 
 #include <memory>
 #include <optional>  // NOLINT : https://github.com/ament/ament_lint/pull/324
@@ -62,4 +62,4 @@ private:
 };
 }  // namespace topic_tools
 
-#endif  // TOPIC_TOOLS__MUX_NODE_HPP_
+#endif  // TOPIC_TOOLS__DEMUX_NODE_HPP_

--- a/topic_tools/include/topic_tools/demux_node.hpp
+++ b/topic_tools/include/topic_tools/demux_node.hpp
@@ -1,0 +1,65 @@
+// Copyright 2024 Rufus Wong
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TOPIC_TOOLS__MUX_NODE_HPP_
+#define TOPIC_TOOLS__MUX_NODE_HPP_
+
+#include <memory>
+#include <optional>  // NOLINT : https://github.com/ament/ament_lint/pull/324
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "topic_tools/tool_base_node.hpp"
+#include "topic_tools_interfaces/srv/demux_add.hpp"
+#include "topic_tools_interfaces/srv/demux_delete.hpp"
+#include "topic_tools_interfaces/srv/demux_list.hpp"
+#include "topic_tools_interfaces/srv/demux_select.hpp"
+
+namespace topic_tools
+{
+static const char NONE_TOPIC[] = "__none";
+
+class DemuxNode final : public ToolBaseNode
+{
+public:
+  TOPIC_TOOLS_PUBLIC
+  explicit DemuxNode(const rclcpp::NodeOptions & options);
+
+private:
+  void process_message(std::shared_ptr<rclcpp::SerializedMessage> msg) override;
+  void make_subscribe_unsubscribe_decisions() override;
+  void on_demux_add(
+    const std::shared_ptr<topic_tools_interfaces::srv::DemuxAdd::Request> request,
+    std::shared_ptr<topic_tools_interfaces::srv::DemuxAdd::Response> response);
+  void on_demux_delete(
+    const std::shared_ptr<topic_tools_interfaces::srv::DemuxDelete::Request> request,
+    std::shared_ptr<topic_tools_interfaces::srv::DemuxDelete::Response> response);
+  void on_demux_list(
+    const std::shared_ptr<topic_tools_interfaces::srv::DemuxList::Request> request,
+    std::shared_ptr<topic_tools_interfaces::srv::DemuxList::Response> response);
+  void on_demux_select(
+    const std::shared_ptr<topic_tools_interfaces::srv::DemuxSelect::Request> request,
+    std::shared_ptr<topic_tools_interfaces::srv::DemuxSelect::Response> response);
+
+  std::vector<std::string> input_topics_;
+  rclcpp::Service<topic_tools_interfaces::srv::DemuxAdd>::SharedPtr demux_add_srv_;
+  rclcpp::Service<topic_tools_interfaces::srv::DemuxDelete>::SharedPtr demux_delete_srv_;
+  rclcpp::Service<topic_tools_interfaces::srv::DemuxList>::SharedPtr demux_list_srv_;
+  rclcpp::Service<topic_tools_interfaces::srv::DemuxSelect>::SharedPtr demux_select_srv_;
+};
+}  // namespace topic_tools
+
+#endif  // TOPIC_TOOLS__MUX_NODE_HPP_

--- a/topic_tools/package.xml
+++ b/topic_tools/package.xml
@@ -11,7 +11,6 @@
   <maintainer email="ros-tooling@googlegroups.com">ROS Tooling Working Group</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 

--- a/topic_tools/package.xml
+++ b/topic_tools/package.xml
@@ -11,6 +11,7 @@
   <maintainer email="ros-tooling@googlegroups.com">ROS Tooling Working Group</maintainer>
   <license>Apache License 2.0</license>
 
+  <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 

--- a/topic_tools/src/demux.cpp
+++ b/topic_tools/src/demux.cpp
@@ -27,8 +27,7 @@ int main(int argc, char * argv[])
   if (args.size() >= 3) {
     options.append_parameter_override("input_topic", args.at(1));
     options.append_parameter_override(
-      "output_topics",
-      std::vector<std::string>{args.begin() + 2, args.end()});
+      "output_topics", std::vector<std::string>{args.begin() + 2, args.end()});
   }
 
   auto node = std::make_shared<topic_tools::DemuxNode>(options);
@@ -37,4 +36,3 @@ int main(int argc, char * argv[])
   rclcpp::shutdown();
   return 0;
 }
-

--- a/topic_tools/src/demux.cpp
+++ b/topic_tools/src/demux.cpp
@@ -1,0 +1,40 @@
+// Copyright 2024 Rufus Wong
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "topic_tools/demux_node.hpp"
+
+int main(int argc, char * argv[])
+{
+  auto args = rclcpp::init_and_remove_ros_arguments(argc, argv);
+  auto options = rclcpp::NodeOptions{};
+
+  if (args.size() >= 3) {
+    options.append_parameter_override("input_topic", args.at(1));
+    options.append_parameter_override(
+      "output_topics",
+      std::vector<std::string>{args.begin() + 2, args.end()});
+  }
+
+  auto node = std::make_shared<topic_tools::DemuxNode>(options);
+
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}
+

--- a/topic_tools/src/demux.cpp
+++ b/topic_tools/src/demux.cpp
@@ -24,11 +24,18 @@ int main(int argc, char * argv[])
   auto args = rclcpp::init_and_remove_ros_arguments(argc, argv);
   auto options = rclcpp::NodeOptions{};
 
-  if (args.size() >= 3) {
-    options.append_parameter_override("input_topic", args.at(1));
-    options.append_parameter_override(
-      "output_topics", std::vector<std::string>{args.begin() + 2, args.end()});
+  if (args.size() < 3) {
+    RCLCPP_ERROR(
+        rclcpp::get_logger("demux"),
+        "Incorect number of arguments. "
+        "Usage: "
+        "ros2 run topic_tools demux <intopic> <outtopic1> [outtopic2...]");
+    return 1;
   }
+
+  options.append_parameter_override("input_topic", args.at(1));
+  options.append_parameter_override(
+      "output_topics", std::vector<std::string>{args.begin() + 2, args.end()});
 
   auto node = std::make_shared<topic_tools::DemuxNode>(options);
 

--- a/topic_tools/src/demux_node.cpp
+++ b/topic_tools/src/demux_node.cpp
@@ -31,7 +31,7 @@ DemuxNode::DemuxNode(const rclcpp::NodeOptions & options)
   using std::placeholders::_2;
 
   output_topic_ = declare_parameter("initial_topic", "");
-  input_topic_ = declare_parameter("input_topic", "~/selected");
+  input_topic_ = declare_parameter("input_topic", "~/input");
   lazy_ = false;
   output_topics_ = declare_parameter<std::vector<std::string>>("output_topics");
   if (output_topic_.empty()) {

--- a/topic_tools/src/demux_node.cpp
+++ b/topic_tools/src/demux_node.cpp
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "topic_tools/demux_node.hpp"
+
 #include <memory>
-#include <optional> // NOLINT : https://github.com/ament/ament_lint/pull/324
+#include <optional>  // NOLINT : https://github.com/ament/ament_lint/pull/324
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "rclcpp/rclcpp.hpp"
-#include "topic_tools/demux_node.hpp"
 
 namespace topic_tools
 {
@@ -38,8 +39,7 @@ DemuxNode::DemuxNode(const rclcpp::NodeOptions & options)
   }
 
   discovery_timer_ = this->create_wall_timer(
-    discovery_period_,
-    std::bind(&DemuxNode::make_subscribe_unsubscribe_decisions, this));
+    discovery_period_, std::bind(&DemuxNode::make_subscribe_unsubscribe_decisions, this));
 
   make_subscribe_unsubscribe_decisions();
 
@@ -55,8 +55,10 @@ DemuxNode::DemuxNode(const rclcpp::NodeOptions & options)
 
 void DemuxNode::make_subscribe_unsubscribe_decisions()
 {
-  if (output_topic_ != NONE_TOPIC ||
-    std::find(output_topics_.begin(), output_topics_.end(), output_topic_) != output_topics_.end())
+  if (
+    output_topic_ != NONE_TOPIC ||
+    std::find(output_topics_.begin(), output_topics_.end(), output_topic_) !=
+    output_topics_.end())
   {
     ToolBaseNode::make_subscribe_unsubscribe_decisions();
   }
@@ -85,13 +87,12 @@ void DemuxNode::on_demux_add(
     return;
   }
 
-  if (std::find(
-      output_topics_.begin(), output_topics_.end(),
-      request->topic) != output_topics_.end())
+  if (
+    std::find(output_topics_.begin(), output_topics_.end(), request->topic) !=
+    output_topics_.end())
   {
     RCLCPP_WARN(
-      get_logger(),
-      "tried to add a topic that demux was already listening to: [%s]",
+      get_logger(), "tried to add a topic that demux was already listening to: [%s]",
       request->topic.c_str());
     response->success = false;
     return;
@@ -110,14 +111,13 @@ void DemuxNode::on_demux_delete(
   RCLCPP_INFO(get_logger(), "trying to delete %s to demux", request->topic.c_str());
 
   auto it = std::find_if(
-    output_topics_.begin(), output_topics_.end(),
-    [this, &request](const std::string & topic) {
-      return get_node_topics_interface()->resolve_topic_name(
-        topic) == get_node_topics_interface()->resolve_topic_name(request->topic);
-    }
-  );
+    output_topics_.begin(), output_topics_.end(), [this, &request](const std::string & topic) {
+      return get_node_topics_interface()->resolve_topic_name(topic) ==
+      get_node_topics_interface()->resolve_topic_name(request->topic);
+    });
   if (it != output_topics_.end()) {
-    if (get_node_topics_interface()->resolve_topic_name(output_topic_) ==
+    if (
+      get_node_topics_interface()->resolve_topic_name(output_topic_) ==
       get_node_topics_interface()->resolve_topic_name(request->topic))
     {
       RCLCPP_WARN(
@@ -133,8 +133,7 @@ void DemuxNode::on_demux_delete(
   }
 
   RCLCPP_WARN(
-    get_logger(), "tried to delete non-subscribed topic %s from demux",
-    request->topic.c_str());
+    get_logger(), "tried to delete non-subscribed topic %s from demux", request->topic.c_str());
   response->success = false;
 }
 
@@ -149,13 +148,12 @@ void DemuxNode::on_demux_select(
   const std::shared_ptr<topic_tools_interfaces::srv::DemuxSelect::Request> request,
   std::shared_ptr<topic_tools_interfaces::srv::DemuxSelect::Response> response)
 {
-  auto it = std::find_if(
-    output_topics_.begin(), output_topics_.end(),
-    [this](const std::string & topic) {
-      return get_node_topics_interface()->resolve_topic_name(
-        topic) == get_node_topics_interface()->resolve_topic_name(output_topic_);
-    }
-  );
+  auto it =
+    std::find_if(
+    output_topics_.begin(), output_topics_.end(), [this](const std::string & topic) {
+      return get_node_topics_interface()->resolve_topic_name(topic) ==
+      get_node_topics_interface()->resolve_topic_name(output_topic_);
+    });
   if (it != output_topics_.end()) {
     response->prev_topic = output_topic_;
   } else {
@@ -169,12 +167,10 @@ void DemuxNode::on_demux_select(
   } else {
     RCLCPP_INFO(get_logger(), "trying to switch demux to %s", request->topic.c_str());
     it = std::find_if(
-      output_topics_.begin(), output_topics_.end(),
-      [this, &request](const std::string & topic) {
-        return get_node_topics_interface()->resolve_topic_name(
-          topic) == get_node_topics_interface()->resolve_topic_name(request->topic);
-      }
-    );
+      output_topics_.begin(), output_topics_.end(), [this, &request](const std::string & topic) {
+        return get_node_topics_interface()->resolve_topic_name(topic) ==
+        get_node_topics_interface()->resolve_topic_name(request->topic);
+      });
     if (it != output_topics_.end()) {
       output_topic_ = request->topic;
       make_subscribe_unsubscribe_decisions();

--- a/topic_tools/src/demux_node.cpp
+++ b/topic_tools/src/demux_node.cpp
@@ -113,7 +113,7 @@ void DemuxNode::on_demux_delete(
   auto it = std::find_if(
     output_topics_.begin(), output_topics_.end(), [this, &request](const std::string & topic) {
       return get_node_topics_interface()->resolve_topic_name(topic) ==
-      get_node_topics_interface()->resolve_topic_name(request->topic);
+             get_node_topics_interface()->resolve_topic_name(request->topic);
     });
   if (it != output_topics_.end()) {
     if (
@@ -152,7 +152,7 @@ void DemuxNode::on_demux_select(
     std::find_if(
     output_topics_.begin(), output_topics_.end(), [this](const std::string & topic) {
       return get_node_topics_interface()->resolve_topic_name(topic) ==
-      get_node_topics_interface()->resolve_topic_name(output_topic_);
+             get_node_topics_interface()->resolve_topic_name(output_topic_);
     });
   if (it != output_topics_.end()) {
     response->prev_topic = output_topic_;
@@ -169,7 +169,7 @@ void DemuxNode::on_demux_select(
     it = std::find_if(
       output_topics_.begin(), output_topics_.end(), [this, &request](const std::string & topic) {
         return get_node_topics_interface()->resolve_topic_name(topic) ==
-        get_node_topics_interface()->resolve_topic_name(request->topic);
+               get_node_topics_interface()->resolve_topic_name(request->topic);
       });
     if (it != output_topics_.end()) {
       output_topic_ = request->topic;

--- a/topic_tools/src/demux_node.cpp
+++ b/topic_tools/src/demux_node.cpp
@@ -30,13 +30,14 @@ DemuxNode::DemuxNode(const rclcpp::NodeOptions & options)
   using std::placeholders::_1;
   using std::placeholders::_2;
 
-  output_topic_ = declare_parameter("initial_topic", "");
+  std::string initial_topic = declare_parameter("initial_topic", "");
   input_topic_ = declare_parameter("input_topic", "~/input");
   lazy_ = false;
   output_topics_ = declare_parameter<std::vector<std::string>>("output_topics");
-  if (output_topic_.empty()) {
-    output_topic_ = output_topics_.front();
+  if (initial_topic.empty()) {
+    initial_topic = output_topics_.front();
   }
+  output_topic_ = initial_topic;
 
   discovery_timer_ = this->create_wall_timer(
     discovery_period_, std::bind(&DemuxNode::make_subscribe_unsubscribe_decisions, this));

--- a/topic_tools/src/demux_node.cpp
+++ b/topic_tools/src/demux_node.cpp
@@ -32,7 +32,7 @@ DemuxNode::DemuxNode(const rclcpp::NodeOptions & options)
 
   output_topic_ = declare_parameter("initial_topic", "");
   input_topic_ = declare_parameter("input_topic", "~/selected");
-  lazy_ = declare_parameter<bool>("lazy", false);
+  lazy_ = false;
   output_topics_ = declare_parameter<std::vector<std::string>>("output_topics");
   if (output_topic_.empty()) {
     output_topic_ = output_topics_.front();

--- a/topic_tools/src/demux_node.cpp
+++ b/topic_tools/src/demux_node.cpp
@@ -1,0 +1,190 @@
+// Copyright 2024 Rufus Wong
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <optional> // NOLINT : https://github.com/ament/ament_lint/pull/324
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "topic_tools/demux_node.hpp"
+
+namespace topic_tools
+{
+DemuxNode::DemuxNode(const rclcpp::NodeOptions & options)
+: ToolBaseNode("demux", options)
+{
+  using std::placeholders::_1;
+  using std::placeholders::_2;
+
+  input_topic_ = declare_parameter("initial_topic", "");
+  output_topic_ = declare_parameter("output_topic", "~/selected");
+  lazy_ = declare_parameter<bool>("lazy", false);
+  input_topics_ = declare_parameter<std::vector<std::string>>("input_topics");
+  if (input_topic_.empty()) {
+    input_topic_ = input_topics_.front();
+  }
+
+  discovery_timer_ = this->create_wall_timer(
+    discovery_period_,
+    std::bind(&DemuxNode::make_subscribe_unsubscribe_decisions, this));
+
+  make_subscribe_unsubscribe_decisions();
+
+  demux_add_srv_ = create_service<topic_tools_interfaces::srv::DemuxAdd>(
+    "~/add", std::bind(&DemuxNode::on_demux_add, this, _1, _2));
+  demux_delete_srv_ = create_service<topic_tools_interfaces::srv::DemuxDelete>(
+    "~/delete", std::bind(&DemuxNode::on_demux_delete, this, _1, _2));
+  demux_list_srv_ = create_service<topic_tools_interfaces::srv::DemuxList>(
+    "~/list", std::bind(&DemuxNode::on_demux_list, this, _1, _2));
+  demux_select_srv_ = create_service<topic_tools_interfaces::srv::DemuxSelect>(
+    "~/select", std::bind(&DemuxNode::on_demux_select, this, _1, _2));
+}
+
+void DemuxNode::make_subscribe_unsubscribe_decisions()
+{
+  if (input_topic_ != NONE_TOPIC ||
+    std::find(input_topics_.begin(), input_topics_.end(), input_topic_) != input_topics_.end())
+  {
+    ToolBaseNode::make_subscribe_unsubscribe_decisions();
+  }
+}
+
+void DemuxNode::process_message(std::shared_ptr<rclcpp::SerializedMessage> msg)
+{
+  std::scoped_lock lock(pub_mutex_);
+  if (!pub_) {
+    return;
+  }
+  pub_->publish(*msg);
+}
+
+void DemuxNode::on_demux_add(
+  const std::shared_ptr<topic_tools_interfaces::srv::DemuxAdd::Request> request,
+  std::shared_ptr<topic_tools_interfaces::srv::DemuxAdd::Response> response)
+{
+  RCLCPP_INFO(get_logger(), "trying to add %s to demux", request->topic.c_str());
+
+  if (request->topic == NONE_TOPIC) {
+    RCLCPP_WARN(
+      get_logger(), "failed to add topic %s to demux, because it's reserved for special use",
+      request->topic.c_str());
+    response->success = false;
+    return;
+  }
+
+  if (std::find(
+      input_topics_.begin(), input_topics_.end(),
+      request->topic) != input_topics_.end())
+  {
+    RCLCPP_WARN(
+      get_logger(),
+      "tried to add a topic that demux was already listening to: [%s]",
+      request->topic.c_str());
+    response->success = false;
+    return;
+  }
+
+  input_topics_.push_back(request->topic);
+
+  RCLCPP_INFO(get_logger(), "added %s to demux", request->topic.c_str());
+  response->success = true;
+}
+
+void DemuxNode::on_demux_delete(
+  const std::shared_ptr<topic_tools_interfaces::srv::DemuxDelete::Request> request,
+  std::shared_ptr<topic_tools_interfaces::srv::DemuxDelete::Response> response)
+{
+  RCLCPP_INFO(get_logger(), "trying to delete %s to demux", request->topic.c_str());
+
+  auto it = std::find_if(
+    input_topics_.begin(), input_topics_.end(),
+    [this, &request](const std::string & topic) {
+      return get_node_topics_interface()->resolve_topic_name(
+        topic) == get_node_topics_interface()->resolve_topic_name(request->topic);
+    }
+  );
+  if (it != input_topics_.end()) {
+    if (get_node_topics_interface()->resolve_topic_name(input_topic_) ==
+      get_node_topics_interface()->resolve_topic_name(request->topic))
+    {
+      RCLCPP_WARN(
+        get_logger(), "tried to delete currently selected topic %s from demux",
+        request->topic.c_str());
+      response->success = false;
+      return;
+    }
+    input_topics_.erase(it);
+    RCLCPP_INFO(get_logger(), "deleted topic %s from demux", request->topic.c_str());
+    response->success = true;
+    return;
+  }
+
+  RCLCPP_WARN(
+    get_logger(), "tried to delete non-subscribed topic %s from demux",
+    request->topic.c_str());
+  response->success = false;
+}
+
+void DemuxNode::on_demux_list(
+  [[maybe_unused]] const std::shared_ptr<topic_tools_interfaces::srv::DemuxList::Request> request,
+  std::shared_ptr<topic_tools_interfaces::srv::DemuxList::Response> response)
+{
+  response->topics = input_topics_;
+}
+
+void DemuxNode::on_demux_select(
+  const std::shared_ptr<topic_tools_interfaces::srv::DemuxSelect::Request> request,
+  std::shared_ptr<topic_tools_interfaces::srv::DemuxSelect::Response> response)
+{
+  auto it = std::find_if(
+    input_topics_.begin(), input_topics_.end(),
+    [this](const std::string & topic) {
+      return get_node_topics_interface()->resolve_topic_name(
+        topic) == get_node_topics_interface()->resolve_topic_name(input_topic_);
+    }
+  );
+  if (it != input_topics_.end()) {
+    response->prev_topic = input_topic_;
+  } else {
+    response->prev_topic = "";
+  }
+
+  if (request->topic == NONE_TOPIC) {
+    RCLCPP_INFO(get_logger(), "demux selected to no input.");
+    input_topic_ = NONE_TOPIC;
+    response->success = true;
+  } else {
+    RCLCPP_INFO(get_logger(), "trying to switch demux to %s", request->topic.c_str());
+    it = std::find_if(
+      input_topics_.begin(), input_topics_.end(),
+      [this, &request](const std::string & topic) {
+        return get_node_topics_interface()->resolve_topic_name(
+          topic) == get_node_topics_interface()->resolve_topic_name(request->topic);
+      }
+    );
+    if (it != input_topics_.end()) {
+      input_topic_ = request->topic;
+      make_subscribe_unsubscribe_decisions();
+      RCLCPP_INFO(get_logger(), "demux selected input: [%s]", request->topic.c_str());
+      response->success = true;
+    }
+  }
+}
+
+}  // namespace topic_tools
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(topic_tools::DemuxNode)

--- a/topic_tools/src/mux.cpp
+++ b/topic_tools/src/mux.cpp
@@ -24,12 +24,18 @@ int main(int argc, char * argv[])
   auto args = rclcpp::init_and_remove_ros_arguments(argc, argv);
   auto options = rclcpp::NodeOptions{};
 
-  if (args.size() >= 3) {
-    options.append_parameter_override("output_topic", args.at(1));
-    options.append_parameter_override(
-      "input_topics",
-      std::vector<std::string>{args.begin() + 2, args.end()});
+  if (args.size() < 3) {
+    RCLCPP_ERROR(
+        rclcpp::get_logger("mux"),
+        "Incorect number of arguments. "
+        "Usage: "
+        "ros2 run topic_tools mux <outtopic> <intopic1> [intopic2...]");
+    return 1;
   }
+
+  options.append_parameter_override("output_topic", args.at(1));
+  options.append_parameter_override(
+      "input_topics", std::vector<std::string>{args.begin() + 2, args.end()});
 
   auto node = std::make_shared<topic_tools::MuxNode>(options);
 

--- a/topic_tools/src/mux_node.cpp
+++ b/topic_tools/src/mux_node.cpp
@@ -29,13 +29,14 @@ MuxNode::MuxNode(const rclcpp::NodeOptions & options)
   using std::placeholders::_1;
   using std::placeholders::_2;
 
-  input_topic_ = declare_parameter("initial_topic", "");
+  std::string initial_topic = declare_parameter("initial_topic", "");
   output_topic_ = declare_parameter("output_topic", "~/selected");
   lazy_ = declare_parameter<bool>("lazy", false);
   input_topics_ = declare_parameter<std::vector<std::string>>("input_topics");
-  if (input_topic_.empty()) {
-    input_topic_ = input_topics_.front();
+  if (initial_topic.empty()) {
+    initial_topic = input_topics_.front();
   }
+  input_topic_ = initial_topic;
 
   discovery_timer_ = this->create_wall_timer(
     discovery_period_,

--- a/topic_tools/src/tool_base_node.cpp
+++ b/topic_tools/src/tool_base_node.cpp
@@ -31,7 +31,8 @@ void ToolBaseNode::make_subscribe_unsubscribe_decisions()
 {
   if (auto source_info = try_discover_source()) {
     // publisher exists already but needs changing if output_topic_ changes
-    if (pub_ &&
+    if (
+      pub_ &&
       pub_->get_topic_name() != get_node_topics_interface()->resolve_topic_name(output_topic_))
     {
       pub_.reset();

--- a/topic_tools/src/tool_base_node.cpp
+++ b/topic_tools/src/tool_base_node.cpp
@@ -31,9 +31,9 @@ void ToolBaseNode::make_subscribe_unsubscribe_decisions()
 {
   if (auto source_info = try_discover_source()) {
     // publisher exists already but needs changing if output_topic_ changes
-    if (
-      pub_ &&
-      pub_->get_topic_name() != get_node_topics_interface()->resolve_topic_name(output_topic_))
+    if (pub_ &&
+      pub_->get_topic_name() !=
+      get_node_topics_interface()->resolve_topic_name(output_topic_))
     {
       pub_.reset();
     }

--- a/topic_tools/src/tool_base_node.cpp
+++ b/topic_tools/src/tool_base_node.cpp
@@ -30,6 +30,13 @@ ToolBaseNode::ToolBaseNode(const std::string & node_name, const rclcpp::NodeOpti
 void ToolBaseNode::make_subscribe_unsubscribe_decisions()
 {
   if (auto source_info = try_discover_source()) {
+    // publisher exists already but needs changing if output_topic_ changes
+    if (pub_ &&
+      pub_->get_topic_name() != get_node_topics_interface()->resolve_topic_name(output_topic_))
+    {
+      pub_.reset();
+    }
+
     // always relay same topic type and QoS profile as the first available source
     if (!topic_type_ || !qos_profile_ || *topic_type_ != source_info->first ||
       *qos_profile_ != source_info->second || !pub_)

--- a/topic_tools/test/test_demux.cpp
+++ b/topic_tools/test/test_demux.cpp
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <memory>
 #include <string>
-#include <chrono>
+
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
-
-#include "topic_tools/demux_node.hpp"
 #include "test_topic_tool.hpp"
+#include "topic_tools/demux_node.hpp"
 
 class DemuxTest : public TestTopicToolMultiPub
 {
@@ -35,12 +35,11 @@ public:
     options.append_parameter_override("output_topics", get_target_output_topics());
     target_node_ = std::make_shared<topic_tools::DemuxNode>(options);
 
-    srv_client_ = test_node_->create_client<topic_tools_interfaces::srv::DemuxSelect>("/demux/select");
+    srv_client_ =
+      test_node_->create_client<topic_tools_interfaces::srv::DemuxSelect>("/demux/select");
 
     std::function<void(std_msgs::msg::String::ConstSharedPtr)> validator =
-      [](std_msgs::msg::String::ConstSharedPtr msg) {
-        ASSERT_EQ(msg->data, "not dropped");
-      };
+      [](std_msgs::msg::String::ConstSharedPtr msg) {ASSERT_EQ(msg->data, "not dropped");};
     set_msg_validator(validator);
   }
 
@@ -61,8 +60,7 @@ public:
     rclcpp::spin_some(target_node_);
   }
 
-  void publish_and_check(
-    std::string msg_content)
+  void publish_and_check(std::string msg_content)
   {
     TestTopicToolMultiPub::publish_and_check(msg_content, target_node_);
   }
@@ -72,19 +70,22 @@ private:
   std::shared_ptr<rclcpp::Node> target_node_;
 };
 
-TEST_F(DemuxTest, MessagesToTheSelectedTopicArrive) {
+TEST_F(DemuxTest, MessagesToTheSelectedTopicArrive)
+{
   publish_and_check("not dropped");
 
   ASSERT_EQ(get_received_msgs(0), 1);
 }
 
-TEST_F(DemuxTest, MessagesToNonSelectedTopicDontArrive) {
+TEST_F(DemuxTest, MessagesToNonSelectedTopicDontArrive)
+{
   publish_and_check("not dropped");
 
   ASSERT_EQ(get_received_msgs(1), 0);
 }
 
-TEST_F(DemuxTest, SwitchingTopicsWorks) {
+TEST_F(DemuxTest, SwitchingTopicsWorks)
+{
   publish_and_check("not dropped");
   ASSERT_EQ(get_received_msgs(1), 0);
   change_topic(1);

--- a/topic_tools/test/test_demux.cpp
+++ b/topic_tools/test/test_demux.cpp
@@ -79,15 +79,15 @@ TEST_F(DemuxTest, MessagesToTheSelectedTopicArrive) {
 }
 
 TEST_F(DemuxTest, MessagesToNonSelectedTopicDontArrive) {
-  publish_and_check("dropped");
+  publish_and_check("not dropped");
 
   ASSERT_EQ(get_received_msgs(1), 0);
 }
 
 TEST_F(DemuxTest, SwitchingTopicsWorks) {
-  publish_and_check("to 0");
+  publish_and_check("not dropped");
   ASSERT_EQ(get_received_msgs(1), 0);
   change_topic(1);
-  publish_and_check("to 1");
+  publish_and_check("not dropped");
   ASSERT_EQ(get_received_msgs(1), 1);
 }

--- a/topic_tools/test/test_demux.cpp
+++ b/topic_tools/test/test_demux.cpp
@@ -1,0 +1,100 @@
+// Copyright 2024 Rufus Wong
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+#include <chrono>
+#include "gtest/gtest.h"
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
+
+#include "topic_tools/demux_node.hpp"
+#include "test_topic_tool.hpp"
+
+class DemuxTest : public TestTopicToolMultiSub
+{
+public:
+  void SetUp()
+  {
+    TestTopicToolMultiSub::SetUp();
+
+    auto options = rclcpp::NodeOptions{};
+    options.append_parameter_override("initial_topic", get_target_input_topics()[0]);
+    options.append_parameter_override("output_topic", get_target_output_topic());
+    options.append_parameter_override("input_topics", get_target_input_topics());
+    target_node_ = std::make_shared<topic_tools::DemuxNode>(options);
+
+    srv_client_ = test_node_->create_client<topic_tools_interfaces::srv::DemuxSelect>("/demux/select");
+
+    std::function<void(std_msgs::msg::String::ConstSharedPtr)> validator =
+      [](std_msgs::msg::String::ConstSharedPtr msg) {
+        ASSERT_EQ(msg->data, "not dropped");
+      };
+    set_msg_validator(validator);
+  }
+
+  void change_topic(int topic_index)
+  {
+    using namespace std::chrono_literals;
+
+    auto request = std::make_shared<topic_tools_interfaces::srv::DemuxSelect::Request>();
+    request->topic = get_target_input_topics()[topic_index];
+
+    while (!srv_client_->wait_for_service(1s)) {
+      if (!rclcpp::ok()) {
+        return;
+      }
+    }
+
+    auto result = srv_client_->async_send_request(request);
+    rclcpp::spin_some(target_node_);
+  }
+
+  void publish_and_check(
+    std::string msg_content,
+    int publisher_index)
+  {
+    TestTopicToolMultiSub::publish_and_check(msg_content, publisher_index, target_node_);
+  }
+
+private:
+  rclcpp::Client<topic_tools_interfaces::srv::DemuxSelect>::SharedPtr srv_client_;
+  std::shared_ptr<rclcpp::Node> target_node_;
+};
+
+TEST_F(DemuxTest, MessagesToTheSelectedTopicArrive) {
+  publish_and_check("not dropped", 0);
+
+  ASSERT_EQ(get_received_msgs(), 1);
+}
+
+TEST_F(DemuxTest, MessagesToNonSelectedTopicDontArrive) {
+  publish_and_check("dropped", 1);
+
+  ASSERT_EQ(get_received_msgs(), 0);
+}
+
+TEST_F(DemuxTest, SwitchingTopicsWorks) {
+  int expect_to_receive = 0;
+
+  publish_and_check("not dropped", 0);
+  expect_to_receive++;
+
+  change_topic(1);
+  publish_and_check("dropped", 0);
+  publish_and_check("not dropped", 1);
+  expect_to_receive++;
+
+  ASSERT_EQ(get_received_msgs(), expect_to_receive);
+}

--- a/topic_tools/test/test_topic_tool.hpp
+++ b/topic_tools/test/test_topic_tool.hpp
@@ -74,9 +74,9 @@ public:
     target_input_topic_ = "/" + test_name + "/input";
     target_output_topic_ = "/" + test_name + "/output";
     subscription_ = test_node_->create_subscription<std_msgs::msg::String>(
-        target_output_topic_, 10,
-        /* lambda used here instead of bind to have default arguments work */
-        [this](std_msgs::msg::String::ConstSharedPtr msg) {this->topic_callback(msg);});
+      target_output_topic_, 10,
+      /* lambda used here instead of bind to have default arguments work */
+      [this](std_msgs::msg::String::ConstSharedPtr msg) {this->topic_callback(msg);});
     publisher_ = test_node_->create_publisher<std_msgs::msg::String>(target_input_topic_, 10);
   }
 
@@ -128,8 +128,8 @@ public:
     target_input_topic_prefix_ = "/" + test_name + "/input";
     target_output_topic_ = "/" + test_name + "/output";
     subscription_ = test_node_->create_subscription<std_msgs::msg::String>(
-        target_output_topic_, 10,
-        [this](std_msgs::msg::String::ConstSharedPtr msg) {this->topic_callback(msg);});
+      target_output_topic_, 10,
+      [this](std_msgs::msg::String::ConstSharedPtr msg) {this->topic_callback(msg);});
     std::vector<std::string> topic_names = get_target_input_topics();
     for (size_t i = 0; i < topic_names.size(); i++) {
       publishers_[i] = test_node_->create_publisher<std_msgs::msg::String>(
@@ -185,27 +185,28 @@ private:
   std::string target_output_topic_;
 };
 
-class TestTopicToolMultiPub : public TestTopicTool {
+class TestTopicToolMultiPub : public TestTopicTool
+{
 public:
-  void SetUp() {
+  void SetUp()
+  {
     using std::placeholders::_1;
-    const std::string test_name =
-        ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    const std::string test_name = ::testing::UnitTest::GetInstance()->current_test_info()->name();
     test_node_ = rclcpp::Node::make_shared(test_name);
     target_input_topic_ = "/" + test_name + "/input";
     target_output_topic_prefix_ = "/" + test_name + "/output";
-    publisher_ = test_node_->create_publisher<std_msgs::msg::String>(
-        target_input_topic_, 10);
+    publisher_ = test_node_->create_publisher<std_msgs::msg::String>(target_input_topic_, 10);
     std::vector<std::string> topic_names = get_target_output_topics();
     set_number_of_subscriptions(topic_names.size());
     for (size_t i = 0; i < topic_names.size(); i++) {
       subscriptions_[i] = test_node_->create_subscription<std_msgs::msg::String>(
-          topic_names[i], 10,
-          [this,i](std_msgs::msg::String::ConstSharedPtr msg) {this->topic_callback(msg, i);});
+        topic_names[i], 10,
+        [this, i](std_msgs::msg::String::ConstSharedPtr msg) {this->topic_callback(msg, i);});
     }
   }
 
-  void TearDown() {
+  void TearDown()
+  {
     test_node_.reset();
     publisher_.reset();
     for (int i = 0; i < num_target_output_topics_; i++) {
@@ -213,8 +214,8 @@ public:
     }
   }
 
-  void publish_and_check(std::string msg_content,
-                         std::shared_ptr<rclcpp::Node> target_node) {
+  void publish_and_check(std::string msg_content, std::shared_ptr<rclcpp::Node> target_node)
+  {
     auto message = std_msgs::msg::String();
     message.data = msg_content;
     publisher_->publish(message);
@@ -222,7 +223,8 @@ public:
     rclcpp::spin_some(test_node_);
   }
 
-  std::vector<std::string> get_target_output_topics() {
+  std::vector<std::string> get_target_output_topics()
+  {
     std::vector<std::string> res;
     for (int i = 0; i < num_target_output_topics_; i++) {
       res.push_back(target_output_topic_prefix_ + std::to_string(i));
@@ -230,7 +232,7 @@ public:
     return res;
   }
 
-  std::string get_target_input_topic() { return target_input_topic_; }
+  std::string get_target_input_topic() {return target_input_topic_;}
 
 protected:
   std::shared_ptr<rclcpp::Node> test_node_;
@@ -238,8 +240,8 @@ protected:
 private:
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
   static constexpr int num_target_output_topics_ = 3;
-  std::array<rclcpp::Subscription<std_msgs::msg::String>::SharedPtr,
-    num_target_output_topics_> subscriptions_;
+  std::array<rclcpp::Subscription<std_msgs::msg::String>::SharedPtr, num_target_output_topics_>
+  subscriptions_;
   std::string target_output_topic_prefix_;
   std::string target_input_topic_;
 };

--- a/topic_tools/test/test_topic_tool.hpp
+++ b/topic_tools/test/test_topic_tool.hpp
@@ -35,26 +35,31 @@ public:
     rclcpp::shutdown();
   }
 
+  void set_number_of_subscriptions(size_t num_subscriptions = 0)
+  {
+    received_msgs_ = std::vector<int>(num_subscriptions, 0);
+  }
+
   void set_msg_validator(const std::function<void(std_msgs::msg::String::ConstSharedPtr)> & f)
   {
     msg_validator_ = f;
   }
 
-  int get_received_msgs()
+  int get_received_msgs(size_t subscription_idx = 0)
   {
-    return received_msgs_;
+    return received_msgs_[subscription_idx];
   }
 
 protected:
-  void topic_callback(std_msgs::msg::String::ConstSharedPtr msg)
+  void topic_callback(std_msgs::msg::String::ConstSharedPtr msg, size_t subscription_idx = 0)
   {
     msg_validator_(msg);
-    received_msgs_++;
+    received_msgs_[subscription_idx]++;
   }
 
 private:
   std::function<void(std_msgs::msg::String::ConstSharedPtr)> msg_validator_;
-  int received_msgs_{0};
+  std::vector<int> received_msgs_{0};
 };
 
 class TestTopicToolSingleSub : public TestTopicTool
@@ -69,7 +74,9 @@ public:
     target_input_topic_ = "/" + test_name + "/input";
     target_output_topic_ = "/" + test_name + "/output";
     subscription_ = test_node_->create_subscription<std_msgs::msg::String>(
-      target_output_topic_, 10, std::bind(&TestTopicToolSingleSub::topic_callback, this, _1));
+        target_output_topic_, 10,
+        /* lambda used here instead of bind to have default arguments work */
+        [this](std_msgs::msg::String::ConstSharedPtr msg) {this->topic_callback(msg);});
     publisher_ = test_node_->create_publisher<std_msgs::msg::String>(target_input_topic_, 10);
   }
 
@@ -121,7 +128,8 @@ public:
     target_input_topic_prefix_ = "/" + test_name + "/input";
     target_output_topic_ = "/" + test_name + "/output";
     subscription_ = test_node_->create_subscription<std_msgs::msg::String>(
-      target_output_topic_, 10, std::bind(&TestTopicToolMultiSub::topic_callback, this, _1));
+        target_output_topic_, 10,
+        [this](std_msgs::msg::String::ConstSharedPtr msg) {this->topic_callback(msg);});
     std::vector<std::string> topic_names = get_target_input_topics();
     for (size_t i = 0; i < topic_names.size(); i++) {
       publishers_[i] = test_node_->create_publisher<std_msgs::msg::String>(
@@ -175,4 +183,63 @@ private:
     num_target_input_topics_> publishers_;
   std::string target_input_topic_prefix_;
   std::string target_output_topic_;
+};
+
+class TestTopicToolMultiPub : public TestTopicTool {
+public:
+  void SetUp() {
+    using std::placeholders::_1;
+    const std::string test_name =
+        ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    test_node_ = rclcpp::Node::make_shared(test_name);
+    target_input_topic_ = "/" + test_name + "/input";
+    target_output_topic_prefix_ = "/" + test_name + "/output";
+    publisher_ = test_node_->create_publisher<std_msgs::msg::String>(
+        target_input_topic_, 10);
+    std::vector<std::string> topic_names = get_target_output_topics();
+    set_number_of_subscriptions(topic_names.size());
+    for (size_t i = 0; i < topic_names.size(); i++) {
+      subscriptions_[i] = test_node_->create_subscription<std_msgs::msg::String>(
+          topic_names[i], 10,
+          [this,i](std_msgs::msg::String::ConstSharedPtr msg) {this->topic_callback(msg, i);});
+    }
+  }
+
+  void TearDown() {
+    test_node_.reset();
+    publisher_.reset();
+    for (int i = 0; i < num_target_output_topics_; i++) {
+      subscriptions_[i].reset();
+    }
+  }
+
+  void publish_and_check(std::string msg_content,
+                         std::shared_ptr<rclcpp::Node> target_node) {
+    auto message = std_msgs::msg::String();
+    message.data = msg_content;
+    publisher_->publish(message);
+    rclcpp::spin_some(target_node);
+    rclcpp::spin_some(test_node_);
+  }
+
+  std::vector<std::string> get_target_output_topics() {
+    std::vector<std::string> res;
+    for (int i = 0; i < num_target_output_topics_; i++) {
+      res.push_back(target_output_topic_prefix_ + std::to_string(i));
+    }
+    return res;
+  }
+
+  std::string get_target_input_topic() { return target_input_topic_; }
+
+protected:
+  std::shared_ptr<rclcpp::Node> test_node_;
+
+private:
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
+  static constexpr int num_target_output_topics_ = 3;
+  std::array<rclcpp::Subscription<std_msgs::msg::String>::SharedPtr,
+    num_target_output_topics_> subscriptions_;
+  std::string target_output_topic_prefix_;
+  std::string target_input_topic_;
 };

--- a/topic_tools_interfaces/CMakeLists.txt
+++ b/topic_tools_interfaces/CMakeLists.txt
@@ -15,6 +15,10 @@ find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
 rosidl_generate_interfaces(${PROJECT_NAME}
+  "srv/DemuxAdd.srv"
+  "srv/DemuxDelete.srv"
+  "srv/DemuxList.srv"
+  "srv/DemuxSelect.srv"
   "srv/MuxAdd.srv"
   "srv/MuxDelete.srv"
   "srv/MuxList.srv"

--- a/topic_tools_interfaces/CMakeLists.txt
+++ b/topic_tools_interfaces/CMakeLists.txt
@@ -11,8 +11,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
+find_package(rosidl_default_generators REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/DemuxAdd.srv"
@@ -32,4 +32,4 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_auto_package()
+ament_package()

--- a/topic_tools_interfaces/CMakeLists.txt
+++ b/topic_tools_interfaces/CMakeLists.txt
@@ -11,6 +11,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 

--- a/topic_tools_interfaces/package.xml
+++ b/topic_tools_interfaces/package.xml
@@ -8,7 +8,6 @@
   <maintainer email="ros-tooling@googlegroups.com">ROS Tooling Working Group</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <build_depend>rosidl_default_generators</build_depend>
 

--- a/topic_tools_interfaces/package.xml
+++ b/topic_tools_interfaces/package.xml
@@ -8,6 +8,7 @@
   <maintainer email="ros-tooling@googlegroups.com">ROS Tooling Working Group</maintainer>
   <license>Apache License 2.0</license>
 
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>rosidl_default_generators</build_depend>
 

--- a/topic_tools_interfaces/srv/DemuxAdd.srv
+++ b/topic_tools_interfaces/srv/DemuxAdd.srv
@@ -1,0 +1,3 @@
+string topic
+---
+bool success

--- a/topic_tools_interfaces/srv/DemuxDelete.srv
+++ b/topic_tools_interfaces/srv/DemuxDelete.srv
@@ -1,0 +1,3 @@
+string topic
+---
+bool success

--- a/topic_tools_interfaces/srv/DemuxList.srv
+++ b/topic_tools_interfaces/srv/DemuxList.srv
@@ -1,0 +1,2 @@
+---
+string[] topics

--- a/topic_tools_interfaces/srv/DemuxSelect.srv
+++ b/topic_tools_interfaces/srv/DemuxSelect.srv
@@ -1,0 +1,4 @@
+string topic
+---
+string prev_topic
+bool success


### PR DESCRIPTION
Completes https://github.com/ros-tooling/topic_tools/issues/105

This PR porting https://github.com/ros/ros_comm/blob/noetic-devel/tools/topic_tools/src/demux.cpp to the ROS 2.

> demux is a generic ROS topic demultiplexer: one input topic is fanned out to 1 of N output topics. A service is provided to select between the outputs

Design choices:
- Callbacks use lambda instead of `std::bind` to get default arguments working