### PR TITLE
Fix unsubscribing when switching to none topic

### DIFF
--- a/topic_tools/src/mux_node.cpp
+++ b/topic_tools/src/mux_node.cpp
@@ -166,6 +166,9 @@ void MuxNode::on_mux_select(
   if (request->topic == NONE_TOPIC) {
     RCLCPP_INFO(get_logger(), "mux selected to no input.");
     input_topic_ = NONE_TOPIC;
+    // Calling the base class's function directly here because NONE_TOPIC is assumed to have no
+    // publishers. Continuously polling through the derived function is unnecessary effort.
+    ToolBaseNode::make_subscribe_unsubscribe_decisions();
     response->success = true;
   } else {
     RCLCPP_INFO(get_logger(), "trying to switch mux to %s", request->topic.c_str());


### PR DESCRIPTION
# Description

This PR fixes an issue with the `mux` node where switching to the `__none` topic did not cause the node to unsubscribe from its previous topic.

The node now calls the `ToolBaseNode::make_subscribe_unsubscribe_decisions()` function after assigning `input_topic_` to `NONE_TOPIC`.

Closes #110 

## How was this tested?

I added a new unit test.