### PR TITLE
fix: install python executables again

### DIFF
--- a/topic_tools/CMakeLists.txt
+++ b/topic_tools/CMakeLists.txt
@@ -197,4 +197,12 @@ install(DIRECTORY launch
 install(TARGETS relay throttle drop mux demux delay
   DESTINATION lib/${PROJECT_NAME})
 
+
+ament_python_install_package(${PROJECT_NAME}
+  SETUP_CFG
+    ${PROJECT_NAME}/setup.cfg
+  SCRIPTS_DESTINATION
+    lib/${PROJECT_NAME}
+)
+
 ament_package()


### PR DESCRIPTION
- This PR addresses issue https://github.com/ros-tooling/topic_tools/issues/114 