### PR TITLE
fix: cpp install paths

### DIFF
--- a/topic_tools/CMakeLists.txt
+++ b/topic_tools/CMakeLists.txt
@@ -183,12 +183,18 @@ if(BUILD_TESTING)
   )
 endif()
 
-install(TARGETS relay_node relay throttle_node throttle drop_node drop mux_node mux demux_node demux delay_node delay
-  DESTINATION lib/${PROJECT_NAME}
+install(TARGETS relay_node throttle_node drop_node mux_node demux_node delay_node
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
+
+install(TARGETS relay throttle drop mux demux delay
+ DESTINATION lib/${PROJECT_NAME})
 
 ament_package()

--- a/topic_tools/CMakeLists.txt
+++ b/topic_tools/CMakeLists.txt
@@ -195,6 +195,6 @@ install(DIRECTORY launch
 )
 
 install(TARGETS relay throttle drop mux demux delay
- DESTINATION lib/${PROJECT_NAME})
+  DESTINATION lib/${PROJECT_NAME})
 
 ament_package()


### PR DESCRIPTION
I found another issue related to the cpp paths and executables.

When running topic tools cpp nodes I was running into the following problem.

```
[throttle-4] /opt/node/lib/topic_tools/throttle: error while loading shared libraries: libthrottle_node.so: cannot open shared object file: No such file or directory
```
It is basically applying to all the cpp nodes.

When checking the difference between my normal build and the docker build I found that the libs where placed in the wrong path if you just use install spaces.

### Old state

```
ldd workspace/install/topic_tools/lib/topic_tools/throttle 
	linux-vdso.so.1 (0x00007fffe5721000)
	libthrottle_node.so => /home/virtual/workspace/build/topic_tools/libthrottle_node.so (0x00007f4d13168000)
	librclcpp.so => /opt/ros/jazzy/lib/librclcpp.so (0x00007f4d12f10000)
	librcutils.so => /opt/ros/jazzy/lib/librcutils.so (0x00007f4d12ef0000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f4d12c54000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f4d12c27000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f4d12a13000)
	librcl.so => /opt/ros/jazzy/lib/librcl.so (0x00007f4d129cd000)
	libtracetools.so => /opt/ros/jazzy/lib/libtracetools.so (0x00007f4d129b3000)
	libclass_loader.so => /opt/ros/jazzy/lib/libclass_loader.so (0x00007f4d129a0000)
	libconsole_bridge.so.1.0 => /lib/x86_64-linux-gnu/libconsole_bridge.so.1.0 (0x00007f4d1299a000)
	liblibstatistics_collector.so => /opt/ros/jazzy/lib/liblibstatistics_collector.so (0x00007f4d12990000)
	librcl_interfaces__rosidl_typesupport_cpp.so => /opt/ros/jazzy/lib/librcl_interfaces__rosidl_typesupport_cpp.so (0x00007f4d12975000)
	librcl_yaml_param_parser.so => /opt/ros/jazzy/lib/librcl_yaml_param_parser.so (0x00007f4d12969000)
	librosgraph_msgs__rosidl_typesupport_cpp.so => /opt/ros/jazzy/lib/librosgraph_msgs__rosidl_typesupport_cpp.so (0x00007f4d12964000)
	libstatistics_msgs__rosidl_typesupport_cpp.so => /opt/ros/jazzy/lib/libstatistics_msgs__rosidl_typesupport_cpp.so (0x00007f4d1295e000)
	librcl_logging_interface.so => /opt/ros/jazzy/lib/librcl_logging_interface.so (0x00007f4d12957000)
	librmw_implementation.so => /opt/ros/jazzy/lib/librmw_implementation.so (0x00007f4d1294a000)
	libament_index_cpp.so => /opt/ros/jazzy/lib/libament_index_cpp.so (0x00007f4d1293e000)
	libtype_description_interfaces__rosidl_typesupport_c.so => /opt/ros/jazzy/lib/libtype_description_interfaces__rosidl_typesupport_c.so (0x00007f4d12937000)
	librmw.so => /opt/ros/jazzy/lib/librmw.so (0x00007f4d1292c000)
	librosidl_dynamic_typesupport.so => /opt/ros/jazzy/lib/librosidl_dynamic_typesupport.so (0x00007f4d12911000)
	librosidl_typesupport_introspection_cpp.so => /opt/ros/jazzy/lib/librosidl_typesupport_introspection_cpp.so (0x00007f4d1290c000)
	librcpputils.so => /opt/ros/jazzy/lib/librcpputils.so (0x00007f4d128fd000)
	librosidl_runtime_c.so => /opt/ros/jazzy/lib/librosidl_runtime_c.so (0x00007f4d128de000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f4d127f5000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f4d131a0000)
	librcl_logging_spdlog.so => /opt/ros/jazzy/lib/librcl_logging_spdlog.so (0x00007f4d127eb000)
	librcl_interfaces__rosidl_typesupport_c.so => /opt/ros/jazzy/lib/librcl_interfaces__rosidl_typesupport_c.so (0x00007f4d127d9000)
	libtype_description_interfaces__rosidl_generator_c.so => /opt/ros/jazzy/lib/libtype_description_interfaces__rosidl_generator_c.so (0x00007f4d127c1000)
	libyaml-0.so.2 => /lib/x86_64-linux-gnu/libyaml-0.so.2 (0x00007f4d127a0000)
	liblttng-ust.so.1 => /lib/x86_64-linux-gnu/liblttng-ust.so.1 (0x00007f4d1271d000)
	librcl_interfaces__rosidl_generator_c.so => /opt/ros/jazzy/lib/librcl_interfaces__rosidl_generator_c.so (0x00007f4d126cf000)
	librosidl_typesupport_cpp.so => /opt/ros/jazzy/lib/librosidl_typesupport_cpp.so (0x00007f4d126c7000)
	librosgraph_msgs__rosidl_generator_c.so => /opt/ros/jazzy/lib/librosgraph_msgs__rosidl_generator_c.so (0x00007f4d126c2000)
	libstatistics_msgs__rosidl_generator_c.so => /opt/ros/jazzy/lib/libstatistics_msgs__rosidl_generator_c.so (0x00007f4d126b9000)
	librosidl_typesupport_c.so => /opt/ros/jazzy/lib/librosidl_typesupport_c.so (0x00007f4d126b3000)
	libspdlog.so.1.12 => /lib/x86_64-linux-gnu/libspdlog.so.1.12 (0x00007f4d1262c000)
	libservice_msgs__rosidl_generator_c.so => /opt/ros/jazzy/lib/libservice_msgs__rosidl_generator_c.so (0x00007f4d12625000)
	libbuiltin_interfaces__rosidl_generator_c.so => /opt/ros/jazzy/lib/libbuiltin_interfaces__rosidl_generator_c.so (0x00007f4d1261e000)
	libnuma.so.1 => /lib/x86_64-linux-gnu/libnuma.so.1 (0x00007f4d12610000)
	liblttng-ust-common.so.1 => /lib/x86_64-linux-gnu/liblttng-ust-common.so.1 (0x00007f4d12603000)
	liblttng-ust-tracepoint.so.1 => /lib/x86_64-linux-gnu/liblttng-ust-tracepoint.so.1 (0x00007f4d125e6000)
	libfmt.so.9 => /lib/x86_64-linux-gnu/libfmt.so.9 (0x00007f4d125c3000)
```

Where libthrottle_node.so points to the build space not the install space.

### New State

With this PR it points after build to the install space

```
virtual@pfs-thinkpad ~/workspace/install/topic_tools/lib/topic_tools $ ldd throttle 
        linux-vdso.so.1 (0x00007ffd6d12b000)
        libthrottle_node.so => /home/virtual/workspace/install/topic_tools/lib/libthrottle_node.so (0x00007f8663ec9000)
        librclcpp.so => /opt/ros/jazzy/lib/librclcpp.so (0x00007f8663c71000)
        librcutils.so => /opt/ros/jazzy/lib/librcutils.so (0x00007f8663c51000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f86639b5000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f8663988000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f8663774000)
        librcl.so => /opt/ros/jazzy/lib/librcl.so (0x00007f866372e000)
        libtracetools.so => /opt/ros/jazzy/lib/libtracetools.so (0x00007f8663714000)
        libclass_loader.so => /opt/ros/jazzy/lib/libclass_loader.so (0x00007f8663701000)
        libconsole_bridge.so.1.0 => /lib/x86_64-linux-gnu/libconsole_bridge.so.1.0 (0x00007f86636fb000)
        liblibstatistics_collector.so => /opt/ros/jazzy/lib/liblibstatistics_collector.so (0x00007f86636f1000)
        librcl_interfaces__rosidl_typesupport_cpp.so => /opt/ros/jazzy/lib/librcl_interfaces__rosidl_typesupport_cpp.so (0x00007f86636d6000)
        librcl_yaml_param_parser.so => /opt/ros/jazzy/lib/librcl_yaml_param_parser.so (0x00007f86636ca000)
        librosgraph_msgs__rosidl_typesupport_cpp.so => /opt/ros/jazzy/lib/librosgraph_msgs__rosidl_typesupport_cpp.so (0x00007f86636c5000)
        libstatistics_msgs__rosidl_typesupport_cpp.so => /opt/ros/jazzy/lib/libstatistics_msgs__rosidl_typesupport_cpp.so (0x00007f86636bf000)
        librcl_logging_interface.so => /opt/ros/jazzy/lib/librcl_logging_interface.so (0x00007f86636b8000)
        librmw_implementation.so => /opt/ros/jazzy/lib/librmw_implementation.so (0x00007f86636ab000)
        libament_index_cpp.so => /opt/ros/jazzy/lib/libament_index_cpp.so (0x00007f866369f000)
        libtype_description_interfaces__rosidl_typesupport_c.so => /opt/ros/jazzy/lib/libtype_description_interfaces__rosidl_typesupport_c.so (0x00007f8663698000)
        librmw.so => /opt/ros/jazzy/lib/librmw.so (0x00007f866368d000)
        librosidl_dynamic_typesupport.so => /opt/ros/jazzy/lib/librosidl_dynamic_typesupport.so (0x00007f8663672000)
        librosidl_typesupport_introspection_cpp.so => /opt/ros/jazzy/lib/librosidl_typesupport_introspection_cpp.so (0x00007f866366d000)
        librcpputils.so => /opt/ros/jazzy/lib/librcpputils.so (0x00007f866365e000)
        librosidl_runtime_c.so => /opt/ros/jazzy/lib/librosidl_runtime_c.so (0x00007f866363f000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f8663556000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f8663f01000)
        librcl_logging_spdlog.so => /opt/ros/jazzy/lib/librcl_logging_spdlog.so (0x00007f866354c000)
        librcl_interfaces__rosidl_typesupport_c.so => /opt/ros/jazzy/lib/librcl_interfaces__rosidl_typesupport_c.so (0x00007f866353a000)
        libtype_description_interfaces__rosidl_generator_c.so => /opt/ros/jazzy/lib/libtype_description_interfaces__rosidl_generator_c.so (0x00007f8663522000)
        libyaml-0.so.2 => /lib/x86_64-linux-gnu/libyaml-0.so.2 (0x00007f8663501000)
        liblttng-ust.so.1 => /lib/x86_64-linux-gnu/liblttng-ust.so.1 (0x00007f866347e000)
        librcl_interfaces__rosidl_generator_c.so => /opt/ros/jazzy/lib/librcl_interfaces__rosidl_generator_c.so (0x00007f8663430000)
        librosidl_typesupport_cpp.so => /opt/ros/jazzy/lib/librosidl_typesupport_cpp.so (0x00007f8663428000)
        librosgraph_msgs__rosidl_generator_c.so => /opt/ros/jazzy/lib/librosgraph_msgs__rosidl_generator_c.so (0x00007f8663423000)
        libstatistics_msgs__rosidl_generator_c.so => /opt/ros/jazzy/lib/libstatistics_msgs__rosidl_generator_c.so (0x00007f866341a000)
        librosidl_typesupport_c.so => /opt/ros/jazzy/lib/librosidl_typesupport_c.so (0x00007f8663414000)
        libspdlog.so.1.12 => /lib/x86_64-linux-gnu/libspdlog.so.1.12 (0x00007f866338d000)
        libservice_msgs__rosidl_generator_c.so => /opt/ros/jazzy/lib/libservice_msgs__rosidl_generator_c.so (0x00007f8663386000)
        libbuiltin_interfaces__rosidl_generator_c.so => /opt/ros/jazzy/lib/libbuiltin_interfaces__rosidl_generator_c.so (0x00007f866337f000)
        libnuma.so.1 => /lib/x86_64-linux-gnu/libnuma.so.1 (0x00007f8663371000)
        liblttng-ust-common.so.1 => /lib/x86_64-linux-gnu/liblttng-ust-common.so.1 (0x00007f8663364000)
        liblttng-ust-tracepoint.so.1 => /lib/x86_64-linux-gnu/liblttng-ust-tracepoint.so.1 (0x00007f8663347000)
        libfmt.so.9 => /lib/x86_64-linux-gnu/libfmt.so.9 (0x00007f8663324000)
```




