### PR TITLE
Update GitHub CI config to use Jazzy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     name: ament_${{ matrix.linter }}
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
+      image: rostooling/setup-ros-docker:ubuntu-noble-ros-jazzy-ros-base-latest
     strategy:
       fail-fast: false
       matrix:
@@ -28,5 +28,5 @@ jobs:
     - uses: ros-tooling/action-ros-lint@0.1.3
       with:
         linter: ${{ matrix.linter }}
-        distribution: rolling
+        distribution: jazzy
         package-name: topic_tools topic_tools_interfaces

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - rolling
+      - jazzy
   schedule:
     # Run every hour. This helps detect flakiness,
     # and broken external dependencies.
@@ -17,11 +17,11 @@ jobs:
     steps:
     - uses: ros-tooling/setup-ros@v0.7
       with:
-        required-ros-distributions: rolling
+        required-ros-distributions: jazzy
     - uses: ros-tooling/action-ros-ci@v0.3
       with:
         package-name: topic_tools topic_tools_interfaces
-        target-ros2-distro: rolling
+        target-ros2-distro: jazzy
         colcon-defaults: |
           {
             "build": {


### PR DESCRIPTION
This was not updated after branching off of `rolling`, so it's still using Rolling.