### PR TITLE
Fixed relative topic resolution in RelayField and Transform node

### DIFF
--- a/topic_tools/topic_tools/relay_field.py
+++ b/topic_tools/topic_tools/relay_field.py
@@ -51,23 +51,19 @@ class RelayField(Node):
         self.msg_generation_lambda = lambda m: self._eval_in_dict_impl(
             self.msg_generation, None, {'m': m})
 
-        input_topic_in_ns = args.input
-        if not input_topic_in_ns.startswith('/'):
-            input_topic_in_ns = self.get_namespace() + args.input
-
         input_class = get_msg_class(
-            self, input_topic_in_ns, blocking=args.wait_for_start, include_hidden_topics=True)
+            self, args.input, blocking=args.wait_for_start, include_hidden_topics=True)
 
         if input_class is None:
-            raise RuntimeError(f'ERROR: Wrong input topic: {input_topic_in_ns}')
+            raise RuntimeError(f'ERROR: Wrong input topic: {args.input}')
 
         self.output_class = get_message(args.output_type)
 
-        qos_profile = self.choose_qos(args, input_topic_in_ns)
+        qos_profile = self.choose_qos(args, args.input)
 
         self.pub = self.create_publisher(self.output_class, args.output_topic, qos_profile)
         self.sub = self.create_subscription(
-            input_class, input_topic_in_ns, self.callback, qos_profile)
+            input_class, args.input, self.callback, qos_profile)
 
     def _eval_in_dict_impl(self, dict_, globals_, locals_):
         res = copy.deepcopy(dict_)

--- a/topic_tools/topic_tools/transform.py
+++ b/topic_tools/topic_tools/transform.py
@@ -72,15 +72,11 @@ class Transform(Node):
         except Exception:
             raise
 
-        input_topic_in_ns = args.input
-        if not input_topic_in_ns.startswith('/'):
-            input_topic_in_ns = self.get_namespace() + args.input
-
         input_class = get_msg_class(
-            self, input_topic_in_ns, blocking=args.wait_for_start, include_hidden_topics=True)
+            self, args.input, blocking=args.wait_for_start, include_hidden_topics=True)
 
         if input_class is None:
-            raise RuntimeError(f'ERROR: Wrong input topic: {input_topic_in_ns}')
+            raise RuntimeError(f'ERROR: Wrong input topic: {args.input}')
 
         self.field = args.field
         if self.field is not None:
@@ -90,11 +86,11 @@ class Transform(Node):
 
         self.output_class = get_message(args.output_type)
 
-        qos_profile = self.choose_qos(args, input_topic_in_ns)
+        qos_profile = self.choose_qos(args, args.input)
 
         self.pub = self.create_publisher(self.output_class, args.output_topic, qos_profile)
         self.sub = self.create_subscription(
-            input_class, input_topic_in_ns, self.callback, qos_profile)
+            input_class, args.input, self.callback, qos_profile)
 
     def choose_qos(self, args, topic_name):
 


### PR DESCRIPTION
Closes #95

Hello everyone,
for some reason, the two python nodes RelayField and Transform have custom logic to resolve relative topics to fully-qualified names. However, the logic is wrong, i.e. the topic `input_topic` in namespace `/robot_a` is resolved to `/robotainput_topic`, so a slash is missing. This makes these two nodes not working with relative topics in namespaces, as also documented in this issue: https://github.com/ros-tooling/topic_tools/issues/95.

This PR simply removes the custom logic for namespace resolution because this is generally handled by the underlying node api.