### PR TITLE
Enable QOS Overrides to All Publishers

### DIFF
--- a/topic_tools/src/tool_base_node.cpp
+++ b/topic_tools/src/tool_base_node.cpp
@@ -38,14 +38,15 @@ void ToolBaseNode::make_subscribe_unsubscribe_decisions()
       pub_.reset();
     }
 
-
     // always relay same topic type and QoS profile as the first available source
     if (!topic_type_ || !qos_profile_ || *topic_type_ != source_info->first ||
       *qos_profile_ != source_info->second || !pub_)
     {
+      topic_type_ = source_info->first;
+      qos_profile_ = source_info->second;
+
       rclcpp::PublisherOptions options;
-      options.qos_overriding_options = rclcpp::QosOverridingOptions
-      {
+      options.qos_overriding_options = rclcpp::QosOverridingOptions({
         rclcpp::QosPolicyKind::Deadline,
         rclcpp::QosPolicyKind::Durability,
         rclcpp::QosPolicyKind::History,
@@ -54,18 +55,17 @@ void ToolBaseNode::make_subscribe_unsubscribe_decisions()
         rclcpp::QosPolicyKind::Liveliness,
         rclcpp::QosPolicyKind::LivelinessLeaseDuration,
         rclcpp::QosPolicyKind::Reliability,
-      };
+      });
 
-      // Generic publisher does NOT declare qos parameters, so we need to do it manually
-      const rclcpp::QoS & actual_qos = options.qos_overriding_options.get_policy_kinds().size() ?
-        rclcpp::detail::declare_qos_parameters(
-        options.qos_overriding_options, *this,
-        this->get_node_topics_interface()->resolve_topic_name(output_topic_),
-        *qos_profile_, rclcpp::detail::PublisherQosParametersTraits{}) :
-        *qos_profile_;
+      // NOTE: Patching a gap in rclcpp, generic_publisher doesn't declare the qos parameters automatically
+      // Keeping this until that's fixed, and passing options through so it'll automatically take effect
+      const rclcpp::QoS & actual_qos = rclcpp::detail::declare_qos_parameters(
+        options.qos_overriding_options,
+        *this,
+        get_node_topics_interface()->resolve_topic_name(output_topic_),
+        *qos_profile_,
+        rclcpp::detail::PublisherQosParametersTraits{});
 
-      topic_type_ = source_info->first;
-      qos_profile_ = source_info->second;
       std::scoped_lock lock(pub_mutex_);
       pub_ = this->create_generic_publisher(output_topic_, *topic_type_, actual_qos, options);
     }

--- a/topic_tools/src/tool_base_node.cpp
+++ b/topic_tools/src/tool_base_node.cpp
@@ -55,10 +55,19 @@ void ToolBaseNode::make_subscribe_unsubscribe_decisions()
         rclcpp::QosPolicyKind::LivelinessLeaseDuration,
         rclcpp::QosPolicyKind::Reliability,
       };
+
+      // Generic publisher does NOT declare qos parameters, so we need to do it manually
+      const rclcpp::QoS & actual_qos = options.qos_overriding_options.get_policy_kinds().size() ?
+      rclcpp::detail::declare_qos_parameters(
+        options.qos_overriding_options, *this,
+        this->get_node_topics_interface()->resolve_topic_name(output_topic_),
+        *qos_profile_, rclcpp::detail::PublisherQosParametersTraits{}) :
+        *qos_profile_;
+
       topic_type_ = source_info->first;
       qos_profile_ = source_info->second;
       std::scoped_lock lock(pub_mutex_);
-      pub_ = this->create_generic_publisher(output_topic_, *topic_type_, *qos_profile_, options);
+      pub_ = this->create_generic_publisher(output_topic_, *topic_type_, actual_qos, options);
     }
     // at this point it is certain that our publisher exists
 

--- a/topic_tools/src/tool_base_node.cpp
+++ b/topic_tools/src/tool_base_node.cpp
@@ -42,9 +42,9 @@ void ToolBaseNode::make_subscribe_unsubscribe_decisions()
     // always relay same topic type and QoS profile as the first available source
     if (!topic_type_ || !qos_profile_ || *topic_type_ != source_info->first ||
       *qos_profile_ != source_info->second || !pub_)
-      {
+    {
       rclcpp::PublisherOptions options;
-      options.qos_overriding_options =  rclcpp::QosOverridingOptions
+      options.qos_overriding_options = rclcpp::QosOverridingOptions
       {
         rclcpp::QosPolicyKind::Deadline,
         rclcpp::QosPolicyKind::Durability,
@@ -58,7 +58,7 @@ void ToolBaseNode::make_subscribe_unsubscribe_decisions()
 
       // Generic publisher does NOT declare qos parameters, so we need to do it manually
       const rclcpp::QoS & actual_qos = options.qos_overriding_options.get_policy_kinds().size() ?
-      rclcpp::detail::declare_qos_parameters(
+        rclcpp::detail::declare_qos_parameters(
         options.qos_overriding_options, *this,
         this->get_node_topics_interface()->resolve_topic_name(output_topic_),
         *qos_profile_, rclcpp::detail::PublisherQosParametersTraits{}) :

--- a/topic_tools/src/tool_base_node.cpp
+++ b/topic_tools/src/tool_base_node.cpp
@@ -38,14 +38,27 @@ void ToolBaseNode::make_subscribe_unsubscribe_decisions()
       pub_.reset();
     }
 
+
     // always relay same topic type and QoS profile as the first available source
     if (!topic_type_ || !qos_profile_ || *topic_type_ != source_info->first ||
       *qos_profile_ != source_info->second || !pub_)
-    {
+      {
+      rclcpp::PublisherOptions options;
+      options.qos_overriding_options =  rclcpp::QosOverridingOptions
+      {
+        rclcpp::QosPolicyKind::Deadline,
+        rclcpp::QosPolicyKind::Durability,
+        rclcpp::QosPolicyKind::History,
+        rclcpp::QosPolicyKind::Depth,
+        rclcpp::QosPolicyKind::Lifespan,
+        rclcpp::QosPolicyKind::Liveliness,
+        rclcpp::QosPolicyKind::LivelinessLeaseDuration,
+        rclcpp::QosPolicyKind::Reliability,
+      };
       topic_type_ = source_info->first;
       qos_profile_ = source_info->second;
       std::scoped_lock lock(pub_mutex_);
-      pub_ = this->create_generic_publisher(output_topic_, *topic_type_, *qos_profile_);
+      pub_ = this->create_generic_publisher(output_topic_, *topic_type_, *qos_profile_, options);
     }
     // at this point it is certain that our publisher exists
 

--- a/topic_tools/src/tool_base_node.cpp
+++ b/topic_tools/src/tool_base_node.cpp
@@ -46,19 +46,20 @@ void ToolBaseNode::make_subscribe_unsubscribe_decisions()
       qos_profile_ = source_info->second;
 
       rclcpp::PublisherOptions options;
-      options.qos_overriding_options = rclcpp::QosOverridingOptions({
-        rclcpp::QosPolicyKind::Deadline,
-        rclcpp::QosPolicyKind::Durability,
-        rclcpp::QosPolicyKind::History,
-        rclcpp::QosPolicyKind::Depth,
-        rclcpp::QosPolicyKind::Lifespan,
-        rclcpp::QosPolicyKind::Liveliness,
-        rclcpp::QosPolicyKind::LivelinessLeaseDuration,
-        rclcpp::QosPolicyKind::Reliability,
-      });
+      options.qos_overriding_options = rclcpp::QosOverridingOptions(
+        {
+          rclcpp::QosPolicyKind::Deadline,
+          rclcpp::QosPolicyKind::Durability,
+          rclcpp::QosPolicyKind::History,
+          rclcpp::QosPolicyKind::Depth,
+          rclcpp::QosPolicyKind::Lifespan,
+          rclcpp::QosPolicyKind::Liveliness,
+          rclcpp::QosPolicyKind::LivelinessLeaseDuration,
+          rclcpp::QosPolicyKind::Reliability,
+        });
 
-      // NOTE: Patching a gap in rclcpp, generic_publisher doesn't declare the qos parameters automatically
-      // Keeping this until that's fixed, and passing options through so it'll automatically take effect
+      // NOTE: Because generic_publisher doesn't currently declare the qos parameters automatically
+      // Passing options through so once that's fixed in rclcpp it'll automatically take effect
       const rclcpp::QoS & actual_qos = rclcpp::detail::declare_qos_parameters(
         options.qos_overriding_options,
         *this,


### PR DESCRIPTION
Enable overriding QoS policies on all topic_tools publishers. This lets a user use, for example, the `relay` node to apply a new QoS, like Deadline to inform the GraphMonitor about its expected frequency