### PR TITLE
Fix race condition on shutdown in try_discover_source()

### DIFF
--- a/topic_tools/src/tool_base_node.cpp
+++ b/topic_tools/src/tool_base_node.cpp
@@ -103,6 +103,12 @@ void ToolBaseNode::make_subscribe_unsubscribe_decisions()
 
 std::optional<std::pair<std::string, rclcpp::QoS>> ToolBaseNode::try_discover_source()
 {
+  // Guard against calls that race with rclcpp::shutdown(): after the context is
+  // invalidated get_publishers_info_by_topic() will throw an RCLError.
+  if (!rclcpp::ok(this->get_node_base_interface()->get_context())) {
+    return {};
+  }
+
   // borrowed this from domain bridge
   // (https://github.com/ros2/domain_bridge/blob/main/src/domain_bridge/wait_for_graph_events.hpp)
   // Query QoS info for publishers


### PR DESCRIPTION
In ros2_control we have been having [issues with topic_tools/relay](https://github.com/ros-controls/topic_based_hardware_interfaces/issues/76) not playing nice with SIGINT and failing tests. RelayNode creates a `discovery_timer_` that fires every 100ms and calls make_subscribe_unsubscribe_decisions() → try_discover_source() → get_publishers_info_by_topic(). When SIGINT is received, `rclcpp::shutdown()` invalidates the context, but the timer can still fire and call `get_publishers_info_by_topic` on the now-invalid context, throwing an uncaught exception.

This PR adds a guard to check for the node shutting down and returns early so the exception is not thrown.